### PR TITLE
Add arrays to XIR

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -44,6 +44,8 @@
 
 ### Bug Fixes
 
+* Building the documentation no longer emits any warnings. [(#25)](https://github.com/XanaduAI/jet/pull/25)
+
 * The output of `TensorNetwork::Contract()` and `TaskBasedCpuContractor::Contract()` now agree with external packages. [(#12)](https://github.com/XanaduAI/jet/pull/12)
 
 * `TaskBasedCpuContractor::AddReductionTask()` now handles the reduction of non-scalar tensors. [(#19)](https://github.com/XanaduAI/jet/pull/19)

--- a/include/jet/Tensor.hpp
+++ b/include/jet/Tensor.hpp
@@ -508,8 +508,7 @@ template <class T = std::complex<float>> class Tensor {
     /**
      * @brief Slices current `%Tensor` object index.
      *
-     * @see SliceIndex(const Tensor<U> &tensor, const std::string &index, size_t
-     * value)
+     * @see SliceIndex(const Tensor<U> &, const std::string &, size_t)
      */
     Tensor<T> SliceIndex(const std::string &index, size_t value) const
     {
@@ -541,8 +540,7 @@ template <class T = std::complex<float>> class Tensor {
     /**
      * @brief Reshapes `%Tensor` object to the given dimensions.
      *
-     * @see Reshape(const Tensor<U> &old_tensor, const std::vector<size_t>
-     * &new_shape)
+     * @see Reshape(const Tensor<U>&, const std::vector<size_t>&)
      */
     Tensor<T> Reshape(const std::vector<size_t> &new_shape) const
     {
@@ -625,8 +623,7 @@ template <class T = std::complex<float>> class Tensor {
     /**
      * @brief Transposes the indices of the `%Tensor` object to a new ordering.
      *
-     * @see Transpose(const Tensor<U> &A, const std::vector<size_t>
-     * &new_ordering)
+     * @see Transpose(const Tensor<U>&, const std::vector<size_t>&)
      */
     Tensor<T> Transpose(const std::vector<size_t> &new_ordering) const
     {
@@ -635,8 +632,7 @@ template <class T = std::complex<float>> class Tensor {
     /**
      * @brief Transposes the indices of the `%Tensor` object to a new ordering.
      *
-     * @see Transpose(const Tensor<U> &A, const std::vector<std::string>
-     * &new_indices)
+     * @see Transpose(const Tensor<U>&, const std::vector<std::string>&)
      */
     Tensor<T> Transpose(const std::vector<std::string> &new_indices) const
     {

--- a/include/jet/Utilities.hpp
+++ b/include/jet/Utilities.hpp
@@ -435,7 +435,7 @@ inline size_t Factorial(size_t n)
  * @param shape Index dimensions.
  * @return Product of the index dimensions in the shape.
  */
-inline size_t ShapeToSize(const std::vector<size_t> &shape) noexcept
+inline size_t ShapeToSize(const std::vector<size_t> &shape)
 {
     size_t size = 1;
     for (const auto &dim : shape) {

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 black
-build
+build==0.4.0
 cmake>=3.14
 isort>5
 pytest>=5,<6


### PR DESCRIPTION
**Context:**
With this, there's now a way of representing states within output statements.

**Description of the Change:**
Adds the `array` type to the grammar, which parses list-lookalike strings (e.g. `"[0, 1, 2]"`) and stores them as python lists. They are currently only possible to define as a value for an output parameter:

```
amplitude(state: [0, 1]) | [0, 1];
```

where the parsed `XIRProgram` has access to the state via `xirprog.statements[0]["state"]`, returning the list `[0, 1]`.

Note: arrays may contain any expression, bool, or string. Nested arrays are allowed.

**Benefits:**
States can now be declared as lists/arrays!

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None