### PR TITLE
Add configuration for Read the Docs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,15 @@
-## Release 0.2.0 (development release)
+## Release 0.3.0 (development release)
+### Documentation
+
+* Read the Docs is now configured to build the Sphinx documentation. [(#51)](https://github.com/XanaduAI/jet/pull/51)
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+[Mikhail Andrenkov](https://github.com/Mandrenkov).
+
+## Release 0.2.0 (current release)
 
 ### New features since last release
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+version: 2
+
+build:
+  image: stable
+  apt_packages:
+    - libopenblas-dev
+    - python3.8-dev
+    - python3-wheel
+    - doxygen
+    - graphviz
+
+python:
+  version: 3.8
+  install:
+    - requirements: docs/requirements.txt
+    - requirements: python/requirements.txt
+    - method: pip
+      path: .
+
+sphinx:
+  configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,13 +4,13 @@ build:
   image: stable
   apt_packages:
     - libopenblas-dev
-    - python3.8-dev
+    - python3.7-dev
     - python3-wheel
     - doxygen
     - graphviz
 
 python:
-  version: 3.8
+  version: 3.7
   install:
     - requirements: docs/requirements.txt
     - requirements: python/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,8 +4,6 @@ build:
   image: latest
   apt_packages:
     - libblas-dev
-    - liblapack-dev
-    - gfortran
     - python3.7-dev
     - python3-wheel
     - doxygen

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   image: latest
   apt_packages:
-    - libopenblas-dev
+    - libgsl-dev
     - python3.7-dev
     - python3-wheel
     - doxygen

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  image: stable
+  image: latest
   apt_packages:
-    - libatlas-base-dev
+    - libopenblas-dev
     - python3.7-dev
     - python3-wheel
     - doxygen

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,6 +3,7 @@ version: 2
 build:
   image: latest
   apt_packages:
+    - libatlas-base-dev
     - libgsl-dev
     - python3.7-dev
     - python3-wheel

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,8 @@ version: 2
 build:
   image: latest
   apt_packages:
-    - libatlas-base-dev
+    - libblas-dev
+    - liblapack-dev
     - gfortran
     - python3.7-dev
     - python3-wheel

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ build:
   image: latest
   apt_packages:
     - libatlas-base-dev
-    - libgsl-dev
+    - gfortran
     - python3.7-dev
     - python3-wheel
     - doxygen

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   image: stable
   apt_packages:
-    - libopenblas-dev
+    - libatlas-base-dev
     - python3.7-dev
     - python3-wheel
     - doxygen

--- a/include/jet/TensorNetwork.hpp
+++ b/include/jet/TensorNetwork.hpp
@@ -463,7 +463,11 @@ template <class Tensor> class TensorNetwork {
         // Create a copy of the indices from the index-to-edge map since this
         // map will be modified in the next loop.
         std::vector<std::string> indices;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
         for (const auto &[index, _] : index_to_edge_map_) {
+#pragma GCC diagnostic pop
             indices.emplace_back(index);
         }
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ class CMakeBuild(build_ext):
             f"-DCMAKE_BUILD_TYPE=Release",
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}",
             f"-DPYTHON_EXECUTABLE={sys.executable}",
-            f"-DENABLE_WARNINGS=Off",
         ]
 
         cmake_cmd = ["cmake", ext.sourcedir] + cmake_args

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ class CMakeBuild(build_ext):
             f"-DCMAKE_BUILD_TYPE=Release",
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}",
             f"-DPYTHON_EXECUTABLE={sys.executable}",
+            f"-DENABLE_WARNINGS=Off",
         ]
 
         cmake_cmd = ["cmake", ext.sourcedir] + cmake_args


### PR DESCRIPTION
**Context:**
Hosting the Sphinx documentation on [Read the Docs](https://readthedocs.org/) improves the accessibility of the Jet documentation.

**Description of the Change:**
- A configuration file has been added for Read the Docs.
- A pragma has been added to suppress a warning about an unused structured binding variable emitted by GCC 7.5.0.

**Benefits:**
- It is possible to view the Jet documentation online at https://quantum-jet.readthedocs.io/.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.