### PR TITLE
Fix documentation links in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,9 +36,9 @@ Features
 * Models quantum systems with an arbitrary number of basis states.
 
 To get started with Jet, read one of our `tutorial walkthroughs
-<https://quantum-jet.readthedocs.io/en/stable/use/introduction.html>`__ or
+<https://quantum-jet.readthedocs.io/en/latest/use/introduction.html>`__ or
 browse the full `API documentation
-<https://quantum-jet.readthedocs.io/en/stable/api/library_root.html>`__.
+<https://quantum-jet.readthedocs.io/en/latest/api/library_root.html>`__.
 
 Installation
 ============


### PR DESCRIPTION
**Context:**

Documentation links were pointing to the wrong location on readthedocs

**Description of the Change:**

Fix these links

**Benefits:**

Working links