### PR TITLE
Prepare for 0.2.1 release

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,6 +1,12 @@
-## Release 0.3.0 (development release)
+## Release 0.2.1 (development release)
+
+### Improvements
+
+* The `CudaTensor` class no longer includes [Taskflow](https://taskflow.github.io/) headers. [(#56)](https://github.com/XanaduAI/jet/pull/56)
 
 ### Documentation
+
+* The `CudaScopedDevice` documentation is now consistent with other classes in Jet. [(#59)](https://github.com/XanaduAI/jet/pull/59)
 
 * The documentation section of the development guide now lists system dependencies. [(#52)](https://github.com/XanaduAI/jet/pull/52)
 
@@ -12,7 +18,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-[Mikhail Andrenkov](https://github.com/Mandrenkov).
+[Mikhail Andrenkov](https://github.com/Mandrenkov), [Trevor Vincent](https://github.com/trevor-vincent).
 
 ## Release 0.2.0 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Release 0.2.1 (development release)
 
+### New features since last release
+
+* The Jet interpreter for XIR scripts now supports an `expval` output. [(#49)](https://github.com/XanaduAI/jet/pull/49)
+
 ### Improvements
 
 * The `CudaTensor` class no longer includes [Taskflow](https://taskflow.github.io/) headers. [(#56)](https://github.com/XanaduAI/jet/pull/56)
@@ -23,8 +27,6 @@ This release contains contributions from (in alphabetical order):
 ## Release 0.2.0 (current release)
 
 ### New features since last release
-
-* The Jet interpreter for XIR scripts now supports an `expval` output. [(#49)](https://github.com/XanaduAI/jet/pull/49)
 
 * The Jet interpreter for XIR scripts now accepts a `dimension` option for CV circuits. [(#47)](https://github.com/XanaduAI/jet/pull/47)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Documentation
 
+* Links to the [Jet paper](https://arxiv.org/abs/2107.09793) are now included in the README and Sphinx documentation. [(#59)](https://github.com/XanaduAI/jet/pull/59)
+
 * The `CudaScopedDevice` documentation is now consistent with other classes in Jet. [(#59)](https://github.com/XanaduAI/jet/pull/59)
 
 * The documentation section of the development guide now lists system dependencies. [(#52)](https://github.com/XanaduAI/jet/pull/52)

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@
     :alt: License
     :target: https://www.apache.org/licenses/LICENSE-2.0
 
-`Jet <https://quantum-jet.readthedocs.io>`_ is a cross-platform C++ library for
+`Jet <https://quantum-jet.readthedocs.io>`_ is a cross-platform library for
 simulating quantum circuits using tensor network contractions.
 
 Features

--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,15 @@ Support
 If you are having issues, please let us know by posting the issue on our GitHub
 issue tracker.
 
+Authors
+=======
+
+Jet is the work of `many contributors <https://github.com/XanaduAI/jet/graphs/contributors>`_.
+
+If you are doing research using Jet, please cite our paper:
+
+    Trevor Vincent, Lee J. O'Riordan, Mikhail Andrenkov, Jack Brown, Nathan Killoran, Haoyu Qi, and Ish Dhand. *Jet: Fast quantum circuit simulations with parallel task-based tensor-network contraction.* 2021. `arxiv:2107.09793 <https://arxiv.org/abs/2107.09793>`_
+
 License
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,8 @@
     :alt: License
     :target: https://www.apache.org/licenses/LICENSE-2.0
 
-`Jet <https://quantum-jet.readthedocs.io>`_ is a cross-platform library for
-simulating quantum circuits using tensor network contractions.
+`Jet <https://quantum-jet.readthedocs.io>`_ is a cross-platform C++ and Python
+library for simulating quantum circuits using tensor network contractions.
 
 Features
 ========

--- a/docs/dev/research.rst
+++ b/docs/dev/research.rst
@@ -4,6 +4,10 @@ Research and contribution
 Research
 --------
 
+If you are doing research using Jet, please cite our paper:
+
+    Trevor Vincent, Lee J. O'Riordan, Mikhail Andrenkov, Jack Brown, Nathan Killoran, Haoyu Qi, and Ish Dhand. *Jet: Fast quantum circuit simulations with parallel task-based tensor-network contraction.* 2021. `arxiv:2107.09793 <https://arxiv.org/abs/2107.09793>`_
+
 We are always open for collaboration, and can be contacted at research@xanadu.ai.
 
 Contribution

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,6 +96,13 @@ Features
 
 * *Qudits.* Models quantum systems with an **arbitrary number of basis states**.
 
+How to cite
+===========
+
+If you are doing research using Jet, please cite our paper:
+
+    Trevor Vincent, Lee J. O'Riordan, Mikhail Andrenkov, Jack Brown, Nathan Killoran, Haoyu Qi, and Ish Dhand. *Jet: Fast quantum circuit simulations with parallel task-based tensor-network contraction.* 2021. `arxiv:2107.09793 <https://arxiv.org/abs/2107.09793>`_
+
 Support
 =======
 

--- a/include/jet/CudaTensorHelpers.hpp
+++ b/include/jet/CudaTensorHelpers.hpp
@@ -176,5 +176,52 @@ ReverseVector(const std::vector<DataType> &input)
     return std::vector<DataType>{input.rbegin(), input.rend()};
 }
 
+/** @class CudaScopedDevice
+
+@brief RAII-styled device context switch. Code taken from Taskflow.
+
+%cudaScopedDevice is neither movable nor copyable.
+*/
+class CudaScopedDevice {
+
+  public:
+    /**
+    @brief constructs a RAII-styled device switcher
+
+    @param device device context to scope in the guard
+    */
+    explicit CudaScopedDevice(int device);
+
+    /**
+    @brief destructs the guard and switches back to the previous device context
+    */
+    ~CudaScopedDevice();
+
+  private:
+    CudaScopedDevice() = delete;
+    CudaScopedDevice(const CudaScopedDevice &) = delete;
+    CudaScopedDevice(CudaScopedDevice &&) = delete;
+
+    int _p;
+};
+
+inline CudaScopedDevice::CudaScopedDevice(int dev)
+{
+    JET_CUDA_IS_SUCCESS(cudaGetDevice(&_p));
+    if (_p == dev) {
+        _p = -1;
+    }
+    else {
+        JET_CUDA_IS_SUCCESS(cudaSetDevice(dev));
+    }
+}
+
+inline CudaScopedDevice::~CudaScopedDevice()
+{
+    if (_p != -1) {
+        cudaSetDevice(_p);
+    }
+}
+
 } // namespace CudaTensorHelpers
 } // namespace Jet


### PR DESCRIPTION
**Context:**
A new (patch) release of Jet is needed to address a compilation issue for `CudaTensor` that was introduced in #50.

**Description of the Change:**
- The changelog now lists version 0.2.1 as the development release.
- The opening line of the Jet README now mentions Python support.
- The Doxygen comments in `CudaScopedDevice` have been formatted and expanded.
- The README and Sphinx documentation now have links to the [Jet paper](https://arxiv.org/abs/2107.09793).

**Benefits:**
- The GitHub and Sphinx documentation is slightly more accurate and therefore more useful.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.