### PR TITLE
Better declarations

### DIFF
--- a/python/tests/jet/test_interpreter.py
+++ b/python/tests/jet/test_interpreter.py
@@ -768,7 +768,7 @@ def test_run_xir_program_with_expval_statements(program, want_result):
             ),
         ),
         (
-            xir.parse_script("operator box, 0, 1; expval(observable: box) | [0];"),
+            xir.parse_script("operator box[0]; expval(observable: box) | [0];"),
             (
                 r"Statement 'expval\(observable: box\) \| \[0\]' has an "
                 r"'observable' parameter which references an undefined operator\."

--- a/python/tests/xir/test_integration.py
+++ b/python/tests/xir/test_integration.py
@@ -17,7 +17,7 @@ photonics_script = """
 gate Sgate(a, b)[0];
 gate BSgate(theta, phi)[0, 1];
 gate Rgate(p0)[0];
-output MeasureHomodyne(p0)[0];
+output MeasureHomodyne[0];
 
 Sgate(0.7, 0) | [1];
 BSgate(0.1, 0.0) | [0, 1];

--- a/python/tests/xir/test_integration.py
+++ b/python/tests/xir/test_integration.py
@@ -14,10 +14,10 @@ def parse_script(circuit: str) -> XIRProgram:
 
 
 photonics_script = """
-gate Sgate, 2, 1;
-gate BSgate, 2, 2;
-gate Rgate, 1, 1;
-output MeasureHomodyne;
+gate Sgate(a, b)[0];
+gate BSgate(theta, phi)[0, 1];
+gate Rgate(p0)[0];
+output MeasureHomodyne(p0)[0];
 
 Sgate(0.7, 0) | [1];
 BSgate(0.1, 0.0) | [0, 1];

--- a/python/tests/xir/test_integration.py
+++ b/python/tests/xir/test_integration.py
@@ -16,11 +16,11 @@ def parse_script(circuit: str) -> XIRProgram:
 photonics_script = """
 gate Sgate(a, b)[0];
 gate BSgate(theta, phi)[0, 1];
-gate Rgate(p0)[0];
+gate Rgate(p0)[a];
 output MeasureHomodyne[0];
 
 Sgate(0.7, 0) | [1];
-BSgate(0.1, 0.0) | [0, 1];
+BSgate(0.1, 0.0) | [0, 2];
 Rgate(0.2) | [1];
 
 MeasureHomodyne(phi: 3) | [0];

--- a/python/tests/xir/test_io.py
+++ b/python/tests/xir/test_io.py
@@ -30,7 +30,8 @@ def create_xir_prog(
 
     # if declaration should be included, add them to the program
     if include_decl:
-        for decl in (Declaration(n, p, w, declaration_type="gate") for n, p, w in data):
+        for i, (n, _, w) in enumerate(data):
+            decl = Declaration(n, declaration_type="gate", params=f"p{i}", wires=w)
             irprog.add_declaration("gate", decl)
 
     # if any external libraries/files are included, add them to the program

--- a/python/tests/xir/test_io.py
+++ b/python/tests/xir/test_io.py
@@ -8,7 +8,7 @@ import strawberryfields as sf
 from strawberryfields import ops
 
 from xir.interfaces.strawberryfields_io import to_program, to_xir
-from xir.program import GateDeclaration, Statement, XIRProgram
+from xir.program import Declaration, Statement, XIRProgram
 
 
 def create_xir_prog(
@@ -30,7 +30,7 @@ def create_xir_prog(
 
     # if declaration should be included, add them to the program
     if include_decl:
-        declarations = [GateDeclaration(n, len(p), len(w)) for n, p, w in data]
+        declarations = [Declaration(n, p, w, declaration_type="gate") for n, p, w in data]
         irprog._declarations["gate"].extend(declarations)
 
     # if any external libraries/files are included, add them to the program
@@ -150,8 +150,8 @@ class TestStrawberryFieldsToXIR:
         if add_decl:
             assert len(irprog.declarations["gate"]) == 1
             assert irprog.declarations["gate"][0].name == "Vacuum"
-            assert irprog.declarations["gate"][0].num_params == 0
-            assert irprog.declarations["gate"][0].num_wires == 1
+            assert irprog.declarations["gate"][0].params == []
+            assert irprog.declarations["gate"][0].wires == (0,)
         else:
             assert irprog.declarations["gate"] == []
 
@@ -178,7 +178,7 @@ class TestStrawberryFieldsToXIR:
         if add_decl:
             assert len(irprog.declarations["gate"]) == 1
             assert irprog.declarations["gate"][0].name == "Sgate"
-            assert irprog.declarations["gate"][0].num_params == 2
-            assert irprog.declarations["gate"][0].num_wires == 1
+            assert irprog.declarations["gate"][0].params == ["p0", "p1"]
+            assert irprog.declarations["gate"][0].wires == (0,)
         else:
             assert irprog.declarations["gate"] == []

--- a/python/tests/xir/test_io.py
+++ b/python/tests/xir/test_io.py
@@ -30,7 +30,7 @@ def create_xir_prog(
 
     # if declaration should be included, add them to the program
     if include_decl:
-        for decl in (Declaration(n, len(p), len(w), declaration_type="gate") for n, p, w in data):
+        for decl in (Declaration(n, p, w, declaration_type="gate") for n, p, w in data):
             irprog.add_declaration("gate", decl)
 
     # if any external libraries/files are included, add them to the program

--- a/python/tests/xir/test_parser.py
+++ b/python/tests/xir/test_parser.py
@@ -133,6 +133,7 @@ class TestParser:
         [
             "adjective name(a, b)[0];",
             "gate name(a, b)[];",
+            "gate name(a: 3, b: 2)[0, 1];",
         ],
     )
     def test_invalid_declarations_token_error(self, circuit):
@@ -144,6 +145,8 @@ class TestParser:
         "circuit",
         [
             "gate name(a, a)[0, 1];",
+            "gate name(5, 3)[0, 1];",
+            "gate name(a, 3)[0, 1];",
         ],
     )
     def test_invalid_declarations_visit_error(self, circuit):

--- a/python/tests/xir/test_parser.py
+++ b/python/tests/xir/test_parser.py
@@ -130,10 +130,11 @@ class TestParser:
             assert irprog.statements[0].params[0] == param.upper()
 
     @pytest.mark.parametrize(
-        "circuit", [
+        "circuit",
+        [
             "adjective name(a, b)[0];",
             "gate name(a, b)[];",
-        ]
+        ],
     )
     def test_invalid_declarations_token_error(self, circuit):
         """Test that an UnexpectedToken error is raised when using invalid declaration syntax"""
@@ -141,9 +142,10 @@ class TestParser:
             parse_script(circuit)
 
     @pytest.mark.parametrize(
-        "circuit", [
+        "circuit",
+        [
             "gate name(a, a)[0, 1];",
-        ]
+        ],
     )
     def test_invalid_declarations_visit_error(self, circuit):
         """Test that a VisitError is raised when using invalid declarations

--- a/python/tests/xir/test_parser.py
+++ b/python/tests/xir/test_parser.py
@@ -1,9 +1,9 @@
 """Unit tests for the parser"""
 
 import math
+import pytest
 from decimal import Decimal
 
-import pytest
 from lark.exceptions import UnexpectedToken, VisitError
 from xir import DecimalComplex, parse_script
 

--- a/python/tests/xir/test_parser.py
+++ b/python/tests/xir/test_parser.py
@@ -2,10 +2,9 @@
 
 import math
 from decimal import Decimal
-from lark.exceptions import UnexpectedToken, VisitError
 
 import pytest
-
+from lark.exceptions import UnexpectedToken, VisitError
 from xir import DecimalComplex, parse_script
 
 

--- a/python/tests/xir/test_parser.py
+++ b/python/tests/xir/test_parser.py
@@ -1,9 +1,9 @@
 """Unit tests for the parser"""
 
 import math
-import pytest
 from decimal import Decimal
 
+import pytest
 from lark.exceptions import UnexpectedToken, VisitError
 from xir import DecimalComplex, parse_script
 

--- a/python/tests/xir/test_parser.py
+++ b/python/tests/xir/test_parser.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 
 import pytest
 from lark.exceptions import UnexpectedToken, VisitError
+
 from xir import DecimalComplex, parse_script
 
 

--- a/python/tests/xir/test_parser.py
+++ b/python/tests/xir/test_parser.py
@@ -2,6 +2,7 @@
 
 import math
 from decimal import Decimal
+from lark.exceptions import UnexpectedToken, VisitError
 
 import pytest
 
@@ -127,3 +128,25 @@ class TestParser:
             assert irprog.statements[0].params[0] == expected
         else:
             assert irprog.statements[0].params[0] == param.upper()
+
+    @pytest.mark.parametrize(
+        "circuit", [
+            "adjective name(a, b)[0];",
+            "gate name(a, b)[];",
+        ]
+    )
+    def test_invalid_declarations_token_error(self, circuit):
+        """Test that an UnexpectedToken error is raised when using invalid declaration syntax"""
+        with pytest.raises(UnexpectedToken, match=r"Unexpected token"):
+            parse_script(circuit)
+
+    @pytest.mark.parametrize(
+        "circuit", [
+            "gate name(a, a)[0, 1];",
+        ]
+    )
+    def test_invalid_declarations_visit_error(self, circuit):
+        """Test that a VisitError is raised when using invalid declarations
+        (that cannot be processed correctly)."""
+        with pytest.raises(VisitError, match=r"Error trying to process rule"):
+            parse_script(circuit)

--- a/python/tests/xir/test_program.py
+++ b/python/tests/xir/test_program.py
@@ -275,24 +275,24 @@ class TestXIRProgram:
 
     def test_add_declaration(self, program):
         """Tests that declarations can be added to an XIR program."""
-        tan = FuncDeclaration("tan", 1)
+        tan = Declaration("tan", ["x"], (), declaration_type="function")
         program.add_declaration("func", tan)
         assert program.declarations == {"func": [tan], "gate": [], "operator": [], "output": []}
 
-        u2 = GateDeclaration("U2", 2, 1)
+        u2 = Declaration("U2", ["a", "b"], (0,), declaration_type="gate")
         program.add_declaration("gate", u2)
         assert program.declarations == {"func": [tan], "gate": [u2], "operator": [], "output": []}
 
-        z3 = GateDeclaration("Z3", 0, 3)
+        z3 = Declaration("Z3", [], (0, 1, 2), declaration_type="gate")
         program.add_declaration("operator", z3)
         assert program.declarations == {"func": [tan], "gate": [u2], "operator": [z3], "output": []}
 
     def test_add_declaration_with_same_key(self, program):
         """Tests that multiple declarations with the same key can be added to an XIR program."""
-        amplitude = OutputDeclaration("amplitude")
+        amplitude = Declaration("amplitude", [], (), declaration_type="output")
         program.add_declaration("output", amplitude)
 
-        probabilities = OutputDeclaration("probabilities")
+        probabilities = Declaration("probabilities", [], (), declaration_type="output")
         program.add_declaration("output", probabilities)
 
         assert program.declarations["output"] == [amplitude, probabilities]
@@ -301,7 +301,7 @@ class TestXIRProgram:
         """Tests that the concrete type of a declaration does not affect the
         key(s) that can be associated with it in an XIR program.
         """
-        decl = OutputDeclaration("gradient")
+        decl = Declaration("gradient", [], (), declaration_type="output")
         program.add_declaration("func", decl)
         assert program.declarations == {"func": [decl], "gate": [], "operator": [], "output": []}
 
@@ -309,7 +309,7 @@ class TestXIRProgram:
         """Tests that an exception is raised when a declaration with an unknown
         key is added to an XIR program.
         """
-        decl = Declaration("Variable")
+        decl = Declaration("var", [], (), declaration_type="gate")
         with pytest.raises(KeyError, match=r"Key 'var' is not a supported declaration"):
             program.add_declaration("var", decl)
 
@@ -317,11 +317,11 @@ class TestXIRProgram:
         """Tests that a warning is issued when two declarations with the same
         name are added to an XIR program.
         """
-        atan1 = FuncDeclaration("atan", 1)
+        atan1 = Declaration("atan", ["x"], (), declaration_type="function")
         program.add_declaration("func", atan1)
 
         with pytest.warns(UserWarning, match=r"Func 'atan' has already been declared"):
-            atan2 = FuncDeclaration("atan", 2)
+            atan2 = Declaration("atan", ["x", "y"], (), declaration_type="function")
             program.add_declaration("func", atan2)
 
         assert program.declarations["func"] == [atan1, atan2]
@@ -511,8 +511,8 @@ class TestXIRProgram:
                     make_program(
                         called_functions={"cos"},
                         declarations={
-                            "func": [FuncDeclaration("cos", 1)],
-                            "gate": [GateDeclaration("H", 0, 1)],
+                            "func": [Declaration("cos", ["x"], (), declaration_type="function")],
+                            "gate": [Declaration("H", [], (0,), declaration_type="gate")],
                             "operator": [],
                             "output": [],
                         },
@@ -526,9 +526,9 @@ class TestXIRProgram:
                     make_program(
                         called_functions={"sin"},
                         declarations={
-                            "func": [FuncDeclaration("sin", 1)],
+                            "func": [Declaration("sin", ["x"], (), declaration_type="function")],
                             "gate": [],
-                            "operator": [OperatorDeclaration("Y", 0, 1)],
+                            "operator": [Declaration("Y", [], (0,), declaration_type="operator")],
                             "output": [],
                         },
                         gates={"D": {"params": ["r", "phi"], "wires": [1], "statements": []}},
@@ -542,9 +542,9 @@ class TestXIRProgram:
                 make_program(
                     called_functions={"cos", "sin"},
                     declarations={
-                        "func": [FuncDeclaration("cos", 1), FuncDeclaration("sin", 1)],
-                        "gate": [GateDeclaration("H", 0, 1)],
-                        "operator": [OperatorDeclaration("Y", 0, 1)],
+                        "func": [Declaration("cos", ["x"], (), declaration_type="function"), Declaration("sin", ["x"], (), declaration_type="function")],
+                        "gate": [Declaration("H", [], (0,), declaration_type="gate")],
+                        "operator": [Declaration("Y", [], (0,), declaration_type="operator")],
                         "output": [],
                     },
                     gates={

--- a/python/tests/xir/test_program.py
+++ b/python/tests/xir/test_program.py
@@ -624,10 +624,10 @@ class TestXIRProgram:
             pytest.param(
                 "play",
                 {
-                    "play": parse_script("output Play;"),
-                    "loop": parse_script("use loop; output Loop;"),
+                    "play": parse_script("func Play;"),
+                    "loop": parse_script("use loop; func Loop;"),
                 },
-                parse_script("output Play;"),
+                parse_script("func Play;"),
                 id="Lazy",
             ),
             pytest.param(
@@ -638,19 +638,19 @@ class TestXIRProgram:
                         use cream;
                         use sugar;
                         use water;
-                        output Coffee;
+                        func Coffee;
                         """
                     ),
-                    "cream": parse_script("output Cream;"),
-                    "sugar": parse_script("output Sugar;"),
-                    "water": parse_script("output Water;"),
+                    "cream": parse_script("func Cream;"),
+                    "sugar": parse_script("func Sugar;"),
+                    "water": parse_script("func Water;"),
                 },
                 parse_script(
                     """
-                    output Cream;
-                    output Sugar;
-                    output Water;
-                    output Coffee;
+                    func Cream;
+                    func Sugar;
+                    func Water;
+                    func Coffee;
                     """
                 ),
                 id="Flat",
@@ -658,15 +658,15 @@ class TestXIRProgram:
             pytest.param(
                 "bot",
                 {
-                    "bot": parse_script("use mid; output Bot;"),
-                    "mid": parse_script("use top; output Mid;"),
-                    "top": parse_script("output Top;"),
+                    "bot": parse_script("use mid; func Bot;"),
+                    "mid": parse_script("use top; func Mid;"),
+                    "top": parse_script("func Top;"),
                 },
                 parse_script(
                     """
-                    output Top;
-                    output Mid;
-                    output Bot;
+                    func Top;
+                    func Mid;
+                    func Bot;
                     """
                 ),
                 id="Linear",
@@ -674,15 +674,15 @@ class TestXIRProgram:
             pytest.param(
                 "salad",
                 {
-                    "salad": parse_script("use lettuce; use spinach; output Salad;"),
-                    "lettuce": parse_script("use spinach; output Lettuce;"),
-                    "spinach": parse_script("output Spinach;"),
+                    "salad": parse_script("use lettuce; use spinach; func Salad;"),
+                    "lettuce": parse_script("use spinach; func Lettuce;"),
+                    "spinach": parse_script("func Spinach;"),
                 },
                 parse_script(
                     """
-                    output Spinach;
-                    output Lettuce;
-                    output Salad;
+                    func Spinach;
+                    func Lettuce;
+                    func Salad;
                     """
                 ),
                 id="Acyclic",
@@ -690,29 +690,29 @@ class TestXIRProgram:
             pytest.param(
                 "Z",
                 {
-                    "Z": parse_script("use K1; use K2; use K3; output Z;"),
-                    "K1": parse_script("use A; use B; use C; output K1;"),
-                    "K2": parse_script("use B; use D; use E; output K2;"),
-                    "K3": parse_script("use A; use D; output K3;"),
-                    "A": parse_script("use O; output A;"),
-                    "B": parse_script("use O; output B;"),
-                    "C": parse_script("use O; output C;"),
-                    "D": parse_script("use O; output D;"),
-                    "E": parse_script("use O; output E;"),
-                    "O": parse_script("output O;"),
+                    "Z": parse_script("use K1; use K2; use K3; func Z;"),
+                    "K1": parse_script("use A; use B; use C; func K1;"),
+                    "K2": parse_script("use B; use D; use E; func K2;"),
+                    "K3": parse_script("use A; use D; func K3;"),
+                    "A": parse_script("use O; func A;"),
+                    "B": parse_script("use O; func B;"),
+                    "C": parse_script("use O; func C;"),
+                    "D": parse_script("use O; func D;"),
+                    "E": parse_script("use O; func E;"),
+                    "O": parse_script("func O;"),
                 },
                 parse_script(
                     """
-                    output O;
-                    output A;
-                    output B;
-                    output C;
-                    output K1;
-                    output D;
-                    output E;
-                    output K2;
-                    output K3;
-                    output Z;
+                    func O;
+                    func A;
+                    func B;
+                    func C;
+                    func K1;
+                    func D;
+                    func E;
+                    func K2;
+                    func K3;
+                    func Z;
                     """
                 ),
                 id="Wikipedia",

--- a/python/tests/xir/test_program.py
+++ b/python/tests/xir/test_program.py
@@ -26,40 +26,36 @@ class TestSerialize:
     # Test declarations
     #####################
 
-    @pytest.mark.parametrize("params", [["a", "b"], [], ["theta"]])
-    @pytest.mark.parametrize("wires", [(0,), (0, 2, 1), ("a", "b", "c")])
-    @pytest.mark.parametrize("declaration_type", ["gate", "operator", "output"])
-    def test_declarations(self, params, wires, declaration_type):
+    @pytest.mark.parametrize("params, wires, declaration_type, want_res", [
+            (["a", "b"], (0,), "gate", "gate name(a, b)[0];"),
+            ([], (0, 2, 1), "operator", "operator name[0, 2, 1];"),
+            (["theta"], ("a", "b", "c"), "output", "output name(theta)[a, b, c];"),
+        ],
+    )
+    def test_declarations(self, params, wires, declaration_type, want_res):
         """Test serializing gate, operation and output declarations"""
         decl = Declaration("name", params, wires, declaration_type=declaration_type)
 
         irprog = XIRProgram()
         irprog._declarations[declaration_type].append(decl)
-        res = irprog.serialize()
+        have_res = irprog.serialize()
 
-        if len(params) == 0:
-            params_str = ""
-        else:
-            params_str = "(" + ", ".join(params) + ")"
+        assert have_res  == want_res
 
-        wires_str = ", ".join(str(w) for w in wires)
-        assert res == f"{declaration_type} name{params_str}[{wires_str}];"
-
-    @pytest.mark.parametrize("params", [["a", "b"], [], ["theta"]])
-    def test_func_declaration(self, params):
+    @pytest.mark.parametrize("params, want_res", [
+            (["a", "b"], "function name(a, b);"),
+            ([], "function name;"),
+            (["theta"], "function name(theta);"),
+        ],
+    )
+    def test_func_declaration(self, params, want_res):
         """Test serializing function declarations"""
         decl = Declaration("name", params, (), declaration_type="function")
 
         irprog = XIRProgram()
         irprog._declarations["func"].append(decl)
-        res = irprog.serialize()
-
-        if len(params) == 0:
-            params_str = ""
-        else:
-            params_str = "(" + ", ".join(params) + ")"
-
-        assert res == f"function name{params_str};"
+        have_res = irprog.serialize()
+        assert have_res  == want_res
 
     ###################
     # Test statements

--- a/python/tests/xir/test_program.py
+++ b/python/tests/xir/test_program.py
@@ -3,13 +3,7 @@
 from decimal import Decimal
 
 import pytest
-
-from xir.program import (
-    XIRProgram,
-    Declaration,
-    Statement,
-    OperatorStmt,
-)
+from xir.program import Declaration, OperatorStmt, Statement, XIRProgram
 
 
 class TestSerialize:

--- a/python/tests/xir/test_program.py
+++ b/python/tests/xir/test_program.py
@@ -57,7 +57,9 @@ class TestSerialize:
     # Test declarations
     #####################
 
-    @pytest.mark.parametrize("params, wires, declaration_type, want_res", [
+    @pytest.mark.parametrize(
+        "params, wires, declaration_type, want_res",
+        [
             (["a", "b"], (0,), "gate", "gate name(a, b)[0];"),
             ([], (0, 2, 1), "operator", "operator name[0, 2, 1];"),
             (["theta"], ("a", "b", "c"), "output", "output name(theta)[a, b, c];"),
@@ -71,9 +73,11 @@ class TestSerialize:
         irprog._declarations[declaration_type].append(decl)
         have_res = irprog.serialize()
 
-        assert have_res  == want_res
+        assert have_res == want_res
 
-    @pytest.mark.parametrize("params, want_res", [
+    @pytest.mark.parametrize(
+        "params, want_res",
+        [
             (["a", "b"], "function name(a, b);"),
             ([], "function name;"),
             (["theta"], "function name(theta);"),
@@ -86,7 +90,7 @@ class TestSerialize:
         irprog = XIRProgram()
         irprog._declarations["func"].append(decl)
         have_res = irprog.serialize()
-        assert have_res  == want_res
+        assert have_res == want_res
 
     ###################
     # Test statements
@@ -557,7 +561,10 @@ class TestXIRProgram:
                 make_program(
                     called_functions={"cos", "sin"},
                     declarations={
-                        "func": [Declaration("cos", declaration_type="function", params=["x"]), Declaration("sin", declaration_type="function", params=["x"])],
+                        "func": [
+                            Declaration("cos", declaration_type="function", params=["x"]),
+                            Declaration("sin", declaration_type="function", params=["x"]),
+                        ],
                         "gate": [Declaration("H", declaration_type="gate", wires=(0,))],
                         "operator": [Declaration("Y", declaration_type="operator", wires=(0,))],
                         "output": [],

--- a/python/tests/xir/test_program.py
+++ b/python/tests/xir/test_program.py
@@ -5,13 +5,10 @@ from decimal import Decimal
 import pytest
 
 from xir.program import (
-    FuncDeclaration,
-    GateDeclaration,
-    OperatorDeclaration,
-    OperatorStmt,
-    OutputDeclaration,
-    Statement,
     XIRProgram,
+    Declaration,
+    Statement,
+    OperatorStmt,
 )
 
 
@@ -35,50 +32,50 @@ class TestSerialize:
     # Test declarations
     #####################
 
-    @pytest.mark.parametrize("name", ["rx", "CNOT", "a_gate"])
-    @pytest.mark.parametrize("num_params", [0, 1, 42])
-    @pytest.mark.parametrize("num_wires", [1, 42])
-    def test_gate_declaration(self, name, num_params, num_wires):
-        """Test serializing gate declarations"""
-        decl = GateDeclaration(name, num_params=num_params, num_wires=num_wires)
+    # @pytest.mark.parametrize("name", ["rx", "CNOT", "a_gate"])
+    # @pytest.mark.parametrize("num_params", [0, 1, 42])
+    # @pytest.mark.parametrize("num_wires", [1, 42])
+    # def test_gate_declaration(self, name, num_params, num_wires):
+    #     """Test serializing gate declarations"""
+    #     decl = GateDeclaration(name, num_params=num_params, num_wires=num_wires)
 
-        irprog = XIRProgram()
-        irprog._declarations["gate"].append(decl)
-        res = irprog.serialize()
-        assert res == f"gate {name}, {num_params}, {num_wires};"
+    #     irprog = XIRProgram()
+    #     irprog._declarations["gate"].append(decl)
+    #     res = irprog.serialize()
+    #     assert res == f"gate {name}, {num_params}, {num_wires};"
 
-    @pytest.mark.parametrize("name", ["sin", "COS", "arc_tan"])
-    @pytest.mark.parametrize("num_params", [0, 1, 42])
-    def test_func_declaration(self, name, num_params):
-        """Test serializing function declarations"""
-        decl = FuncDeclaration(name, num_params=num_params)
+    # @pytest.mark.parametrize("name", ["sin", "COS", "arc_tan"])
+    # @pytest.mark.parametrize("num_params", [0, 1, 42])
+    # def test_func_declaration(self, name, num_params):
+    #     """Test serializing function declarations"""
+    #     decl = FuncDeclaration(name, num_params=num_params)
 
-        irprog = XIRProgram()
-        irprog._declarations["func"].append(decl)
-        res = irprog.serialize()
-        assert res == f"func {name}, {num_params};"
+    #     irprog = XIRProgram()
+    #     irprog._declarations["func"].append(decl)
+    #     res = irprog.serialize()
+    #     assert res == f"func {name}, {num_params};"
 
-    @pytest.mark.parametrize("name", ["op", "OPERATOR", "op_42"])
-    @pytest.mark.parametrize("num_params", [0, 1, 42])
-    @pytest.mark.parametrize("num_wires", [1, 42])
-    def test_operator_declaration(self, name, num_params, num_wires):
-        """Test serializing operator declarations"""
-        decl = OperatorDeclaration(name, num_params=num_params, num_wires=num_wires)
+    # @pytest.mark.parametrize("name", ["op", "OPERATOR", "op_42"])
+    # @pytest.mark.parametrize("num_params", [0, 1, 42])
+    # @pytest.mark.parametrize("num_wires", [1, 42])
+    # def test_operator_declaration(self, name, num_params, num_wires):
+    #     """Test serializing operator declarations"""
+    #     decl = OperatorDeclaration(name, num_params=num_params, num_wires=num_wires)
 
-        irprog = XIRProgram()
-        irprog._declarations["operator"].append(decl)
-        res = irprog.serialize()
-        assert res == f"operator {name}, {num_params}, {num_wires};"
+    #     irprog = XIRProgram()
+    #     irprog._declarations["operator"].append(decl)
+    #     res = irprog.serialize()
+    #     assert res == f"operator {name}, {num_params}, {num_wires};"
 
-    @pytest.mark.parametrize("name", ["sample", "amplitude"])
-    def test_output_declaration(self, name):
-        """Test serializing output declarations"""
-        decl = OutputDeclaration(name)
+    # @pytest.mark.parametrize("name", ["sample", "amplitude"])
+    # def test_output_declaration(self, name):
+    #     """Test serializing output declarations"""
+    #     decl = OutputDeclaration(name)
 
-        irprog = XIRProgram()
-        irprog._declarations["output"].append(decl)
-        res = irprog.serialize()
-        assert res == f"output {name};"
+    #     irprog = XIRProgram()
+    #     irprog._declarations["output"].append(decl)
+    #     res = irprog.serialize()
+    #     assert res == f"output {name};"
 
     ###################
     # Test statements

--- a/python/tests/xir/test_program.py
+++ b/python/tests/xir/test_program.py
@@ -1,8 +1,8 @@
 """Unit tests for the program class"""
 
+import pytest
 from decimal import Decimal
 
-import pytest
 from xir.program import Declaration, OperatorStmt, Statement, XIRProgram
 
 

--- a/python/tests/xir/test_program.py
+++ b/python/tests/xir/test_program.py
@@ -1,8 +1,8 @@
 """Unit tests for the program class"""
 
-import pytest
 from decimal import Decimal
 
+import pytest
 from xir.program import Declaration, OperatorStmt, Statement, XIRProgram
 
 

--- a/python/tests/xir/test_program.py
+++ b/python/tests/xir/test_program.py
@@ -32,50 +32,40 @@ class TestSerialize:
     # Test declarations
     #####################
 
-    # @pytest.mark.parametrize("name", ["rx", "CNOT", "a_gate"])
-    # @pytest.mark.parametrize("num_params", [0, 1, 42])
-    # @pytest.mark.parametrize("num_wires", [1, 42])
-    # def test_gate_declaration(self, name, num_params, num_wires):
-    #     """Test serializing gate declarations"""
-    #     decl = GateDeclaration(name, num_params=num_params, num_wires=num_wires)
+    @pytest.mark.parametrize("params", [["a", "b"], [], ["theta"]])
+    @pytest.mark.parametrize("wires", [(0,), (0, 2, 1), ("a", "b", "c")])
+    @pytest.mark.parametrize("declaration_type", ["gate", "operator", "output"])
+    def test_declarations(self, params, wires, declaration_type):
+        """Test serializing gate, operation and output declarations"""
+        decl = Declaration("name", params, wires, declaration_type=declaration_type)
 
-    #     irprog = XIRProgram()
-    #     irprog._declarations["gate"].append(decl)
-    #     res = irprog.serialize()
-    #     assert res == f"gate {name}, {num_params}, {num_wires};"
+        irprog = XIRProgram()
+        irprog._declarations[declaration_type].append(decl)
+        res = irprog.serialize()
 
-    # @pytest.mark.parametrize("name", ["sin", "COS", "arc_tan"])
-    # @pytest.mark.parametrize("num_params", [0, 1, 42])
-    # def test_func_declaration(self, name, num_params):
-    #     """Test serializing function declarations"""
-    #     decl = FuncDeclaration(name, num_params=num_params)
+        if len(params) == 0:
+            params_str = ""
+        else:
+            params_str = "(" + ", ".join(params) + ")"
 
-    #     irprog = XIRProgram()
-    #     irprog._declarations["func"].append(decl)
-    #     res = irprog.serialize()
-    #     assert res == f"func {name}, {num_params};"
+        wires_str = ", ".join(str(w) for w in wires)
+        assert res == f"{declaration_type} name{params_str}[{wires_str}];"
 
-    # @pytest.mark.parametrize("name", ["op", "OPERATOR", "op_42"])
-    # @pytest.mark.parametrize("num_params", [0, 1, 42])
-    # @pytest.mark.parametrize("num_wires", [1, 42])
-    # def test_operator_declaration(self, name, num_params, num_wires):
-    #     """Test serializing operator declarations"""
-    #     decl = OperatorDeclaration(name, num_params=num_params, num_wires=num_wires)
+    @pytest.mark.parametrize("params", [["a", "b"], [], ["theta"]])
+    def test_func_declaration(self, params):
+        """Test serializing function declarations"""
+        decl = Declaration("name", params, (), declaration_type="function")
 
-    #     irprog = XIRProgram()
-    #     irprog._declarations["operator"].append(decl)
-    #     res = irprog.serialize()
-    #     assert res == f"operator {name}, {num_params}, {num_wires};"
+        irprog = XIRProgram()
+        irprog._declarations["func"].append(decl)
+        res = irprog.serialize()
 
-    # @pytest.mark.parametrize("name", ["sample", "amplitude"])
-    # def test_output_declaration(self, name):
-    #     """Test serializing output declarations"""
-    #     decl = OutputDeclaration(name)
+        if len(params) == 0:
+            params_str = ""
+        else:
+            params_str = "(" + ", ".join(params) + ")"
 
-    #     irprog = XIRProgram()
-    #     irprog._declarations["output"].append(decl)
-    #     res = irprog.serialize()
-    #     assert res == f"output {name};"
+        assert res == f"function name{params_str};"
 
     ###################
     # Test statements

--- a/python/tests/xir/test_program.py
+++ b/python/tests/xir/test_program.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import Any, Dict, Iterable, List, MutableSet
 
 import pytest
+
 from xir import parse_script
 from xir.program import Declaration, OperatorStmt, Statement, XIRProgram
 

--- a/python/tests/xir/test_utils.py
+++ b/python/tests/xir/test_utils.py
@@ -5,10 +5,10 @@ import pytest
 from xir.utils import is_equal
 
 script_1 = """
-gate Sgate, 2, 1;
-gate BSgate, 2, 2;
-gate Rgate, 1, 1;
-output MeasureHomodyne;
+gate Sgate(a, b)[0];
+gate BSgate(theta, phi)[0, 1];
+gate Rgate(p0)[a];
+output MeasureHomodyne[0];
 
 Sgate(0.7, 0) | [1];
 BSgate(0.1, 0.0) | [0, 1];
@@ -28,9 +28,9 @@ MeasureHomodyne(phi: 3) | [0];
 """
 
 script_2 = """
-gate Sgate, 2, 1;
-gate Rgate, 1, 1;
-output MeasureFock;
+gate Sgate(a, b)[0];
+gate Rgate(p0)[a];
+output MeasureHomodyne[0];
 
 Sgate(0.7, 0) | [1];
 Rgate(0.2) | [1];

--- a/python/xir/__init__.py
+++ b/python/xir/__init__.py
@@ -1,6 +1,6 @@
 from .decimal_complex import DecimalComplex
 from .parser import XIRTransformer, xir_parser
-from .program import GateDeclaration, OperatorStmt, Statement, XIRProgram
+from .program import Declaration, OperatorStmt, Statement, XIRProgram
 
 
 def parse_script(circuit: str, **kwargs) -> XIRProgram:

--- a/python/xir/interfaces/strawberryfields_io.py
+++ b/python/xir/interfaces/strawberryfields_io.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 import strawberryfields as sf
 from strawberryfields import ops
 
-from xir.program import GateDeclaration, OutputDeclaration, Statement, XIRProgram
+from xir.program import Declaration, Statement, XIRProgram
 
 
 def to_program(xir, **kwargs):
@@ -98,7 +98,7 @@ def to_xir(prog, **kwargs):
 
         if "Measure" in name:
             if kwargs.get("add_decl", False):
-                output_decl = OutputDeclaration(name)
+                output_decl = Declaration(name, [], (), declaration_type="output")
                 xir._declarations["output"].append(output_decl)
 
             params = dict()
@@ -117,7 +117,7 @@ def to_xir(prog, **kwargs):
         else:
             if kwargs.get("add_decl", False):
                 if name not in [gdecl.name for gdecl in xir._declarations["gate"]]:
-                    gate_decl = GateDeclaration(name, len(cmd.op.p), len(wires))
+                    gate_decl = Declaration(name, [f"p{i}" for i, _ in enumerate(cmd.op.p)], wires, declaration_type="gate")
                     xir._declarations["gate"].append(gate_decl)
 
             params = []

--- a/python/xir/interfaces/strawberryfields_io.py
+++ b/python/xir/interfaces/strawberryfields_io.py
@@ -98,7 +98,7 @@ def to_xir(prog, **kwargs):
 
         if "Measure" in name:
             if kwargs.get("add_decl", False):
-                output_decl = Declaration(name, [], (), declaration_type="output")
+                output_decl = Declaration(name, declaration_type="output")
                 xir.add_declaration("output", output_decl)
 
             params = dict()
@@ -117,7 +117,8 @@ def to_xir(prog, **kwargs):
         else:
             if kwargs.get("add_decl", False):
                 if name not in [gdecl.name for gdecl in xir.declarations["gate"]]:
-                    gate_decl = Declaration(name, [f"p{i}" for i, _ in enumerate(cmd.op.p)], wires, declaration_type="gate")
+                    params = [f"p{i}" for i, _ in enumerate(cmd.op.p)]
+                    gate_decl = Declaration(name, declaration_type="gate", params=params, wires=wires)
                     xir.add_declaration("gate", gate_decl)
 
             params = []

--- a/python/xir/interfaces/strawberryfields_io.py
+++ b/python/xir/interfaces/strawberryfields_io.py
@@ -118,7 +118,9 @@ def to_xir(prog, **kwargs):
             if kwargs.get("add_decl", False):
                 if name not in [gdecl.name for gdecl in xir.declarations["gate"]]:
                     params = [f"p{i}" for i, _ in enumerate(cmd.op.p)]
-                    gate_decl = Declaration(name, declaration_type="gate", params=params, wires=wires)
+                    gate_decl = Declaration(
+                        name, declaration_type="gate", params=params, wires=wires
+                    )
                     xir.add_declaration("gate", gate_decl)
 
             params = []

--- a/python/xir/ir.lark
+++ b/python/xir/ir.lark
@@ -9,8 +9,8 @@ gatestmt: (ADJOINT | (CTRL wires))* name params? "|" wires ";"
 opstmt: expr "," obs_group";"
 script_options: _OPTIONS ":" (option ";")+ _END ";"
 
-gate_def: _GATE name params? wires? ":" gatestmt+ _END ";"
-operator_def: _OP name params? wires? ":" opstmt+ _END ";"
+gate_def: _GATE name params_list? wires? ":" gatestmt+ _END ";"
+operator_def: _OP name params_list? wires? ":" opstmt+ _END ";"
 
 option: name ":" val
 
@@ -20,7 +20,7 @@ obs_group: obs "[" uint "]" ("@" obs "[" uint "]")*
 // list-types
 wires : "[" (uint | range | name) ("," (uint | range | name))* "]"
 
-params: params_dict | params_list
+?params: params_dict | params_list
 params_list: "(" val ("," val)* ")"
 params_dict: "(" option ("," option)* ")"
 
@@ -72,10 +72,10 @@ FALSE_: "false"
 // declarations
 ?declarations: (gate_decl | operator_decl | func_decl | output_decl)
 
-gate_decl: _GATE name params? wires ";"
-operator_decl: _OP name params? wires ";"
-output_decl: _OUT name params? wires ";"
-func_decl: _FUNC name params? ";"
+gate_decl: _GATE name params_list? wires ";"
+operator_decl: _OP name params_list? wires ";"
+output_decl: _OUT name params_list? wires ";"
+func_decl: _FUNC name params_list? ";"
 
 // std imports from common.lark
 %import common.ESCAPED_STRING

--- a/python/xir/ir.lark
+++ b/python/xir/ir.lark
@@ -19,7 +19,11 @@ obs_group: obs "[" uint "]" ("@" obs "[" uint "]")*
 
 // list-types
 wires : "[" (uint | range | name) ("," (uint | range | name))* "]"
-params: "(" (val | option) ("," (val | option))* ")"
+
+params: params_dict | params_list
+params_list: "(" val ("," val)* ")"
+params_dict: "(" option ("," option)* ")"
+
 array : "[" (val ("," val)*)? "]"
 
 ?val  : bool | expr | array

--- a/python/xir/ir.lark
+++ b/python/xir/ir.lark
@@ -5,12 +5,12 @@ include: "use" name ";"
 // the main circuit
 circuit: statement+
 statement: gatestmt | gate_def | operator_def | script_options
-gatestmt: name (params | options_dict) "|" wires ";"
+gatestmt: name (params | options_dict)? "|" wires ";"
 opstmt: expr "," obs_group";"
 script_options: _OPTIONS ":" (option ";")+ _END ";"
 
-gate_def: _GATE name params wires? ":" gatestmt+ _END ";"
-operator_def: _OP name params wires? ":" opstmt+ _END ";"
+gate_def: _GATE name params? wires? ":" gatestmt+ _END ";"
+operator_def: _OP name params? wires? ":" opstmt+ _END ";"
 
 options_dict: "(" option ("," option)* ")"
 option: name ":" val
@@ -20,7 +20,7 @@ obs_group: obs "[" uint "]" ("@" obs "[" uint "]")*
 
 // list-types
 wires : "[" (uint | range | name) ("," (uint | range | name))* "]"
-params: ["(" val ("," val)* ")"]  // always optional (easier to parse)
+params: "(" val ("," val)* ")"
 array : "[" (val ("," val)*)? "]"
 
 ?val  : bool | expr | array
@@ -67,10 +67,10 @@ FALSE_: "false"
 // declarations
 ?declarations: (gate_decl | operator_decl | func_decl | output_decl)
 
-gate_decl: _GATE name "," uint "," uint ";"
-operator_decl: _OP name "," uint "," uint ";"
-func_decl: _FUNC name "," uint ";"
-output_decl: _OUT name ";"
+gate_decl: _GATE name params? wires ";"
+operator_decl: _OP name params? wires ";"
+func_decl: _FUNC name params? ";"
+output_decl: _OUT name params? wires ";"
 
 // std imports from common.lark
 %import common.ESCAPED_STRING

--- a/python/xir/ir.lark
+++ b/python/xir/ir.lark
@@ -5,14 +5,13 @@ include: "use" name ";"
 // the main circuit
 circuit: statement+
 statement: gatestmt | gate_def | operator_def | script_options
-gatestmt: (ADJOINT | (CTRL wires))* name (params | options_dict)? "|" wires ";"
+gatestmt: (ADJOINT | (CTRL wires))* name params? "|" wires ";"
 opstmt: expr "," obs_group";"
 script_options: _OPTIONS ":" (option ";")+ _END ";"
 
 gate_def: _GATE name params? wires? ":" gatestmt+ _END ";"
 operator_def: _OP name params? wires? ":" opstmt+ _END ";"
 
-options_dict: "(" option ("," option)* ")"
 option: name ":" val
 
 obs_group: obs "[" uint "]" ("@" obs "[" uint "]")*
@@ -20,7 +19,7 @@ obs_group: obs "[" uint "]" ("@" obs "[" uint "]")*
 
 // list-types
 wires : "[" (uint | range | name) ("," (uint | range | name))* "]"
-params: "(" val ("," val)* ")"
+params: "(" (val | option) ("," (val | option))* ")"
 array : "[" (val ("," val)*)? "]"
 
 ?val  : bool | expr | array
@@ -71,8 +70,8 @@ FALSE_: "false"
 
 gate_decl: _GATE name params? wires ";"
 operator_decl: _OP name params? wires ";"
-func_decl: _FUNC name params? ";"
 output_decl: _OUT name params? wires ";"
+func_decl: _FUNC name params? ";"
 
 // std imports from common.lark
 %import common.ESCAPED_STRING

--- a/python/xir/parser.py
+++ b/python/xir/parser.py
@@ -328,9 +328,9 @@ class XIRTransformer(Transformer):
     PI = lambda self, _: "PI" if not self._eval_pi else Decimal(str(math.pi))
 
 def is_wire(arg):
-    """TODO"""
+    """Returns whether the passed argument is a tuple of wires."""
     return isinstance(arg, tuple) and arg[0] == "wires"
 
 def is_param(arg):
-    """TODO"""
+    """Returns whether the passed argument is a list of params."""
     return isinstance(arg, tuple) and arg[0] == "params"

--- a/python/xir/parser.py
+++ b/python/xir/parser.py
@@ -2,17 +2,11 @@
 import math
 from decimal import Decimal
 from pathlib import Path
-from typing import Union
 
 from lark import Lark, Transformer
 
 from .decimal_complex import DecimalComplex
-from .program import (
-    XIRProgram,
-    Declaration,
-    Statement,
-    OperatorStmt,
-)
+from .program import Declaration, OperatorStmt, Statement, XIRProgram
 from .utils import check_wires, simplify_math
 
 p = Path(__file__).parent / "ir.lark"

--- a/python/xir/parser.py
+++ b/python/xir/parser.py
@@ -9,8 +9,8 @@ from .decimal_complex import DecimalComplex
 from .program import Declaration, OperatorStmt, Statement, XIRProgram
 from .utils import check_wires, simplify_math
 
-p = Path(__file__).parent / "ir.lark"
-with p.open("r") as _f:
+_p = Path(__file__).parent / "ir.lark"
+with _p.open("r") as _f:
     ir_grammar = _f.read()
 
 xir_parser = Lark(ir_grammar, start="program", parser="lalr")
@@ -264,7 +264,7 @@ class XIRTransformer(Transformer):
             params = []
 
         decl = Declaration(name, declaration_type="gate", params=params, wires=wires)
-        self._program._declarations["gate"].append(decl)
+        self._program.add_declaration("gate", decl)
 
     def operator_decl(self, args):
         if len(args) == 3:
@@ -273,7 +273,7 @@ class XIRTransformer(Transformer):
             name, wires = args[0], args[1][1]
             params = []
         decl = Declaration(name, declaration_type="operator", params=params, wires=wires)
-        self._program._declarations["operator"].append(decl)
+        self._program.add_declaration("operator", decl)
 
     def func_decl(self, args):
         if len(args) == 2:
@@ -282,7 +282,7 @@ class XIRTransformer(Transformer):
             name = args[0]
             params = []
         decl = Declaration(name, declaration_type="function", params=params)
-        self._program._declarations["func"].append(decl)
+        self._program.add_declaration("func", decl)
 
     def output_decl(self, args):
         if len(args) == 3:
@@ -291,7 +291,7 @@ class XIRTransformer(Transformer):
             name, wires = args[0], args[1][1]
             params = []
         decl = Declaration(name, declaration_type="output", params=params, wires=wires)
-        self._program._declarations["output"].append(decl)
+        self._program.add_declaration("output", decl)
 
     #########
     # maths

--- a/python/xir/parser.py
+++ b/python/xir/parser.py
@@ -116,14 +116,13 @@ class XIRTransformer(Transformer):
         """Tuple with wires and identifier"""
         return "wires", tuple(w)
 
-    def params(self, p):
-        """Tuple with params and identifier"""
-        # p will be a list with one element, which is either a list (params_list)
-        # or a dict (params_dict)
-        return "params", p[0]
+    def params_list(self, p):
+        """Tuple with list of params and identifier"""
+        return "params", list(p)
 
-    params_list = list
-    params_dict = dict
+    def params_dict(self, p):
+        """Tuple with dictionary of params and identifier"""
+        return "params", dict(p)
 
     option = tuple
     array = list
@@ -270,7 +269,7 @@ class XIRTransformer(Transformer):
             name, wires = args[0], args[1][1]
             params = []
 
-        decl = Declaration(name, params, wires, declaration_type="gate")
+        decl = Declaration(name, declaration_type="gate", params=params, wires=wires)
         self._program._declarations["gate"].append(decl)
 
     def operator_decl(self, args):
@@ -279,7 +278,7 @@ class XIRTransformer(Transformer):
         else:
             name, wires = args[0], args[1][1]
             params = []
-        decl = Declaration(name, params, wires, declaration_type="operator")
+        decl = Declaration(name, declaration_type="operator", params=params, wires=wires)
         self._program._declarations["operator"].append(decl)
 
     def func_decl(self, args):
@@ -288,7 +287,7 @@ class XIRTransformer(Transformer):
         else:
             name = args[0]
             params = []
-        decl = Declaration(name, params, (), declaration_type="function")
+        decl = Declaration(name, declaration_type="function", params=params)
         self._program._declarations["func"].append(decl)
 
     def output_decl(self, args):
@@ -297,7 +296,7 @@ class XIRTransformer(Transformer):
         else:
             name, wires = args[0], args[1][1]
             params = []
-        decl = Declaration(name, params, wires, declaration_type="output")
+        decl = Declaration(name, declaration_type="output", params=params, wires=wires)
         self._program._declarations["output"].append(decl)
 
     #########
@@ -347,5 +346,5 @@ def is_wire(arg):
 
 
 def is_param(arg):
-    """Returns whether the passed argument is a list of params."""
+    """Returns whether the passed argument is a list or dictionary of params."""
     return isinstance(arg, tuple) and arg[0] == "params"

--- a/python/xir/parser.py
+++ b/python/xir/parser.py
@@ -7,13 +7,10 @@ from lark import Lark, Transformer
 
 from .decimal_complex import DecimalComplex
 from .program import (
-    FuncDeclaration,
-    GateDeclaration,
-    OperatorDeclaration,
-    OperatorStmt,
-    OutputDeclaration,
-    Statement,
     XIRProgram,
+    Declaration,
+    Statement,
+    OperatorStmt,
 )
 from .utils import check_wires, simplify_math
 
@@ -182,7 +179,7 @@ class XIRTransformer(Transformer):
 
     def gatestmt(self, args):
         """Gate statements that are defined directly in the circuit or inside
-        a gate declaration."""
+        a gate definition."""
         name = args[0]
         if isinstance(args[1], list):
             params = simplify_math(args[1])
@@ -197,7 +194,7 @@ class XIRTransformer(Transformer):
         return Statement(name, params, wires, use_floats=self.use_floats)
 
     def opstmt(self, args):
-        """Operator statements defined inside an operator declaration
+        """Operator statements defined inside an operator definition.
 
         Returns:
             OperatorStmt: object containing statement data
@@ -219,19 +216,19 @@ class XIRTransformer(Transformer):
     ###############
 
     def gate_decl(self, args):
-        decl = GateDeclaration(*args)
+        decl = Declaration(*args, declaration_type="gate")
         self._program._declarations["gate"].append(decl)
 
     def operator_decl(self, args):
-        decl = OperatorDeclaration(*args)
+        decl = Declaration(*args, declaration_type="operator")
         self._program._declarations["operator"].append(decl)
 
     def func_decl(self, args):
-        decl = FuncDeclaration(*args)
+        decl = Declaration(*args, declaration_type="function")
         self._program._declarations["func"].append(decl)
 
     def output_decl(self, args):
-        decl = OutputDeclaration(*args)
+        decl = Declaration(*args, declaration_type="output")
         self._program._declarations["output"].append(decl)
 
     #########

--- a/python/xir/parser.py
+++ b/python/xir/parser.py
@@ -111,12 +111,14 @@ class XIRTransformer(Transformer):
         """Tuple with wires and identifier"""
         return "wires", tuple(w)
 
-    def params(self, args):
+    def params(self, p):
         """Tuple with params and identifier"""
-        if all(isinstance(p, tuple) for p in args):
-            return "params", dict(args)
-        return "params", list(args)
+        # p will be a list with one element, which is either a list (params_list)
+        # or a dict (params_dict)
+        return "params", p[0]
 
+    params_list = list
+    params_dict = dict
     option = tuple
     array = list
     FALSE_ = lambda self, _: False

--- a/python/xir/parser.py
+++ b/python/xir/parser.py
@@ -227,7 +227,7 @@ class XIRTransformer(Transformer):
         stmt_options = {
             "ctrl_wires": tuple(sorted(ctrl_wires, key=hash)),
             "adjoint": adjoint,
-            "use_floats": self.use_floats
+            "use_floats": self.use_floats,
         }
         return Statement(name, params, wires, **stmt_options)
 
@@ -329,9 +329,11 @@ class XIRTransformer(Transformer):
 
     PI = lambda self, _: "PI" if not self._eval_pi else Decimal(str(math.pi))
 
+
 def is_wire(arg):
     """Returns whether the passed argument is a tuple of wires."""
     return isinstance(arg, tuple) and arg[0] == "wires"
+
 
 def is_param(arg):
     """Returns whether the passed argument is a list of params."""

--- a/python/xir/program.py
+++ b/python/xir/program.py
@@ -3,7 +3,6 @@
 import re
 import warnings
 from decimal import Decimal
-
 from typing import (
     Any,
     Collection,
@@ -12,10 +11,10 @@ from typing import (
     Mapping,
     MutableMapping,
     MutableSet,
+    Optional,
     Sequence,
     Tuple,
     Union,
-    Optional,
 )
 
 from .decimal_complex import DecimalComplex

--- a/python/xir/program.py
+++ b/python/xir/program.py
@@ -221,8 +221,8 @@ class Declaration:
 
         self.name = name
         self.declaration_type = declaration_type
-        self.params = list(params) or []
-        self.wires = tuple(wires) or ()
+        self.params = list(params or [])
+        self.wires = tuple(wires or ())
 
         if not all(isinstance(p, str) for p in self.params):
             raise TypeError("Declaration '{name}' has parameters which are not strings.")

--- a/python/xir/program.py
+++ b/python/xir/program.py
@@ -192,7 +192,7 @@ class Declaration:
         name (str): name of the declaration
     """
 
-    def __init__(self, name: str, params: Sequence[str], wires: Wires, declaration_type: str):
+    def __init__(self, name: str, params: Sequence[str], wires: Sequence[Wire], declaration_type: str):
         self.name = name
         self.params = list(map(str, params))
         if len(set(self.params)) != len(self.params):
@@ -203,7 +203,7 @@ class Declaration:
         self.declaration_type = declaration_type
 
     def __str__(self) -> str:
-        return _decl_str(self.name, self.params, self.wires, self.declaration_type)
+        return _serialize_declaration(self.name, self.params, self.wires, self.declaration_type)
 
     def __repr__(self) -> str:
         return f"<{self.declaration_type.capitalize()} declaration:name={self.name}>"
@@ -402,7 +402,7 @@ class XIRProgram:
             res.append("")
 
         for name, gate in self._gates.items():
-            decl_str = _decl_str(name, gate["params"], gate["wires"], "gate")
+            decl_str = _serialize_declaration(name, gate["params"], gate["wires"], "gate")
 
             res.append(decl_str + ":")
 
@@ -410,7 +410,7 @@ class XIRProgram:
             res.append("end;\n")
 
         for name, op in self._operators.items():
-            decl_str = _decl_str(name, op["params"], op["wires"], "operator")
+            decl_str = _serialize_declaration(name, op["params"], op["wires"], "operator")
 
             res.append(decl_str + ":")
 

--- a/python/xir/program.py
+++ b/python/xir/program.py
@@ -195,6 +195,8 @@ class Declaration:
     def __init__(self, name: str, params, wires, declaration_type: str):
         self.name = name
         self.params = list(map(str, params))
+        if len(set(self.params)) != len(self.params):
+            raise ValueError("All parameters must be unique")
         self.wires = wires
         if declaration_type not in ("gate", "output", "operator", "function"):
             raise TypeError(f"Declaration type {declaration_type} is not valid.")
@@ -204,7 +206,7 @@ class Declaration:
         return _decl_str(self.name, self.params, self.wires, self.declaration_type)
 
     def __repr__(self) -> str:
-        return f"<{self.declaration_type.capitalize()} declaration:name={self.name}"
+        return f"<{self.declaration_type.capitalize()} declaration:name={self.name}>"
 
 
 class XIRProgram:

--- a/python/xir/program.py
+++ b/python/xir/program.py
@@ -210,7 +210,11 @@ class Declaration:
     """
 
     def __init__(
-        self, name: str, declaration_type: str, params: Optional[Sequence[str]] = None, wires: Optional[Sequence[Wire]] = None
+        self,
+        name: str,
+        declaration_type: str,
+        params: Optional[Sequence[str]] = None,
+        wires: Optional[Sequence[Wire]] = None,
     ) -> None:
         if declaration_type not in ("gate", "output", "operator", "function"):
             raise TypeError(f"Declaration type '{declaration_type}' is invalid.")

--- a/python/xir/program.py
+++ b/python/xir/program.py
@@ -171,10 +171,10 @@ class OperatorStmt:
         return tuple({t[1] for t in self.terms})
 
 
-def _decl_str(name, params, wires, declaration_type):
+def _serialize_declaration(name, params, wires, declaration_type):
     """TODO"""
-    if params != []:
-        params = "(" + ", ".join([str(p) for p in params]) + ")"
+    if len(params):
+        params = "(" + ", ".join(map(str, params)) + ")"
     else:
         params = ""
     if wires != ():
@@ -192,14 +192,14 @@ class Declaration:
         name (str): name of the declaration
     """
 
-    def __init__(self, name: str, params, wires, declaration_type: str):
+    def __init__(self, name: str, params: Sequence[str], wires: Wires, declaration_type: str):
         self.name = name
         self.params = list(map(str, params))
         if len(set(self.params)) != len(self.params):
-            raise ValueError("All parameters must be unique")
+            raise ValueError("All parameters in a declaration must be unique.")
         self.wires = wires
         if declaration_type not in ("gate", "output", "operator", "function"):
-            raise TypeError(f"Declaration type {declaration_type} is not valid.")
+            raise TypeError(f"Declaration type '{declaration_type}' is invalid.")
         self.declaration_type = declaration_type
 
     def __str__(self) -> str:

--- a/python/xir/program.py
+++ b/python/xir/program.py
@@ -57,13 +57,7 @@ class Statement:
             and ``DecimalComplex`` objects. Defaults to ``True``.
     """
 
-    def __init__(
-            self,
-            name: str,
-            params: Params,
-            wires: Sequence[Wire],
-            **kwargs
-        ):
+    def __init__(self, name: str, params: Params, wires: Sequence[Wire], **kwargs):
         self._name = name
         self._params = params
         self._wires = wires
@@ -145,7 +139,7 @@ class OperatorStmt:
 
         self._use_floats = use_floats
 
-    def __str__(self):
+    def __str__(self) -> str:
         terms = [f"{t[0]}[{t[1]}]" for t in self.terms]
         terms_as_string = " @ ".join(terms)
         pref = str(self.pref)
@@ -171,8 +165,10 @@ class OperatorStmt:
         return tuple({t[1] for t in self.terms})
 
 
-def _serialize_declaration(name, params, wires, declaration_type):
-    """TODO"""
+def _serialize_declaration(
+    name: str, params: Sequence[Param], wires: Sequence[Wire], declaration_type
+) -> str:
+    """Constructs and returns a declaration as a serialized string."""
     if len(params):
         params = "(" + ", ".join(map(str, params)) + ")"
     else:
@@ -192,7 +188,9 @@ class Declaration:
         name (str): name of the declaration
     """
 
-    def __init__(self, name: str, params: Sequence[str], wires: Sequence[Wire], declaration_type: str):
+    def __init__(
+        self, name: str, params: Sequence[str], wires: Sequence[Wire], declaration_type: str
+    ) -> None:
         self.name = name
         self.params = list(map(str, params))
         if len(set(self.params)) != len(self.params):
@@ -346,7 +344,9 @@ class XIRProgram:
         """
         return self._called_ops
 
-    def add_gate(self, name: str, params: List[str], wires: Tuple, statements: List[Statement]):
+    def add_gate(
+        self, name: str, params: List[str], wires: Tuple, statements: List[Statement]
+    ) -> None:
         """Adds a gate to the program
 
         Args:
@@ -361,7 +361,7 @@ class XIRProgram:
 
     def add_operator(
         self, name: str, params: List[str], wires: Tuple, statements: List[OperatorStmt]
-    ):
+    ) -> None:
         """Adds an operator to the program
 
         Args:
@@ -397,7 +397,7 @@ class XIRProgram:
             res.extend([f"    {k}: {v};" for k, v in self.options.items()])
             res.append("end;\n")
 
-        res.extend([f"{dec};" for v in self._declarations.values() for dec in v ])
+        res.extend([f"{dec};" for v in self._declarations.values() for dec in v])
         if any(len(dec) != 0 for dec in self._declarations.values()):
             res.append("")
 

--- a/python/xir/program.py
+++ b/python/xir/program.py
@@ -225,9 +225,9 @@ class Declaration:
         self.wires = wires or ()
 
         if not all(isinstance(p, str) for p in self.params):
-            raise TypeError("Declared parameters must be strings.")
+            raise TypeError("Declaration '{name}' has parameters which are not strings.")
         if len(set(self.params)) != len(self.params):
-            raise ValueError("All parameters in a declaration must be unique.")
+            raise ValueError("Declaration '{name}' has duplicate parameters.")
 
     def __str__(self) -> str:
         return _serialize_declaration(self.name, self.params, self.wires, self.declaration_type)

--- a/python/xir/program.py
+++ b/python/xir/program.py
@@ -221,8 +221,8 @@ class Declaration:
 
         self.name = name
         self.declaration_type = declaration_type
-        self.params = params or []
-        self.wires = wires or ()
+        self.params = list(params) or []
+        self.wires = tuple(wires) or ()
 
         if not all(isinstance(p, str) for p in self.params):
             raise TypeError("Declaration '{name}' has parameters which are not strings.")

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ requirements = [
     "lark-parser>=0.11.0",
     "numpy>=1.0.0",
     "StrawberryFields==0.18.0",
-    "thewalrus==0.15.0",
+    "thewalrus>=0.15.0",
 ]
 
 info = {

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ requirements = [
     "lark-parser>=0.11.0",
     "numpy>=1.0.0",
     "StrawberryFields==0.18.0",
-    "thewalrus>=0.15.0",
+    "thewalrus==0.15.0",
 ]
 
 info = {


### PR DESCRIPTION
**Context:**
Declarations are currently very simple and do not provide much information about parameters and wires. This is an issue when interfacing to Jet (which currently uses a work-around).

**Note**: Still need to update the interpreter to use the new declarations.

**Description of the Change:**
Adds better declarations to the XIR.

E.g., `gate BSgate(theta, phi)[0, 1];` instead of `gate BSgate, 2, 2`

**Benefits:**
Parameter and wire names are provided in declaration.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None; see [ch7558].