### PR TITLE
Update Jet version to 0.2.1

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 * The `CudaTensor` class no longer includes [Taskflow](https://taskflow.github.io/) headers. [(#56)](https://github.com/XanaduAI/jet/pull/56)
 
+### Bug Fixes
+
+* The paper benchmarks now fetch the Jet repository at tag "0.2.1". [(#62)](https://github.com/XanaduAI/jet/pull/62)
+
+
 ### Documentation
 
 * Links to the [Jet paper](https://arxiv.org/abs/2107.09793) are now included in the README and Sphinx documentation. [(#59)](https://github.com/XanaduAI/jet/pull/59)

--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ The output of this program should resemble
     (-0.0786964,-0.771624)
     (2.98721,-0.657124)
     (-1.90032,1.58051)
-    You have successfully used Jet version 0.2.0
+    You have successfully used Jet version 0.2.1
 
 For more detailed instructions, see the `development guide
 <https://quantum-jet.readthedocs.io/en/stable/dev/guide.html>`_.
@@ -149,7 +149,7 @@ The output of this program should resemble
     -0.16588-1.44652j
     -1.43005+0.49516j
     1.66881-1.67099j
-    You have successfully used Jet version 0.2.0
+    You have successfully used Jet version 0.2.1
 
 Contributing to Jet
 ===================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,7 +133,7 @@ author = "Xanadu Inc."
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = "0.2.0"
+release = "0.2.1"
 
 # The short X.Y version.
 version = re.match(r"^(\d+\.\d+)", release).expand(r"\1")

--- a/docs/dev/guide.rst
+++ b/docs/dev/guide.rst
@@ -99,7 +99,7 @@ Running the example should produce output similar to:
     (1.53207,0)
     (0.414398,0)
     (0.721263,0)
-    You have successfully used Jet version 0.2.0
+    You have successfully used Jet version 0.2.1
 
 Congratulations, you have successfully run your first Jet program!
 

--- a/examples/paper_benchmarks/CPU/jet_cpu_gbs/CMakeLists.txt
+++ b/examples/paper_benchmarks/CPU/jet_cpu_gbs/CMakeLists.txt
@@ -19,7 +19,7 @@ Include(FetchContent)
 FetchContent_Declare(
     Jet
     GIT_REPOSITORY  git@github.com:XanaduAI/jet.git
-    GIT_TAG         0.2.0
+    GIT_TAG         0.2.1
 )
 FetchContent_MakeAvailable(Jet)
 

--- a/examples/paper_benchmarks/CPU/jet_cpu_m10/CMakeLists.txt
+++ b/examples/paper_benchmarks/CPU/jet_cpu_m10/CMakeLists.txt
@@ -19,7 +19,7 @@ Include(FetchContent)
 FetchContent_Declare(
     Jet
     GIT_REPOSITORY  git@github.com:XanaduAI/jet.git
-    GIT_TAG         0.2.0
+    GIT_TAG         0.2.1
 )
 FetchContent_MakeAvailable(Jet)
 

--- a/examples/paper_benchmarks/CPU/jet_cpu_m12/CMakeLists.txt
+++ b/examples/paper_benchmarks/CPU/jet_cpu_m12/CMakeLists.txt
@@ -19,7 +19,7 @@ Include(FetchContent)
 FetchContent_Declare(
     Jet
     GIT_REPOSITORY  git@github.com:XanaduAI/jet.git
-    GIT_TAG         0.2.0
+    GIT_TAG         0.2.1
 )
 FetchContent_MakeAvailable(Jet)
 

--- a/examples/paper_benchmarks/GPU/jet_gpu_m10/CMakeLists.txt
+++ b/examples/paper_benchmarks/GPU/jet_gpu_m10/CMakeLists.txt
@@ -16,7 +16,7 @@ Include(FetchContent)
 FetchContent_Declare(
     Jet
     GIT_REPOSITORY  git@github.com:XanaduAI/jet.git
-    GIT_TAG         0.2.0
+    GIT_TAG         0.2.1
 )
 FetchContent_MakeAvailable(Jet)
 

--- a/examples/paper_benchmarks/GPU/jet_gpu_m12/CMakeLists.txt
+++ b/examples/paper_benchmarks/GPU/jet_gpu_m12/CMakeLists.txt
@@ -19,7 +19,7 @@ Include(FetchContent)
 FetchContent_Declare(
     Jet
     GIT_REPOSITORY  git@github.com:XanaduAI/jet.git
-    GIT_TAG         0.2.0
+    GIT_TAG         0.2.1
 )
 FetchContent_MakeAvailable(Jet)
 

--- a/include/jet/Version.hpp
+++ b/include/jet/Version.hpp
@@ -11,7 +11,7 @@ constexpr size_t MAJOR_VERSION = 0;
 constexpr size_t MINOR_VERSION = 2;
 
 /// Patch version number of Jet.
-constexpr size_t PATCH_VERSION = 0;
+constexpr size_t PATCH_VERSION = 1;
 
 /**
  * @brief Returns the current Jet version.


### PR DESCRIPTION
**Context:**
The next release of Jet is not reflected in the current version number (0.2.0) returned by the Jet libraries.

**Description of the Change:**
- The patch version of Jet has been incremented across all Jet libraries, examples, benchmarks, and documentation.

**Benefits:**
- The version number returned by the Jet libraries is more accurate.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
Inspired by #55.