### PR TITLE
Use PyLint

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Improvements
 
-* Python source files are now linted using [Flake8](https://flake8.pycqa.org/en/latest/). [(#64)](https://github.com/XanaduAI/jet/pull/64)
+* Python source files are now linted using [PyLint](https://pypi.org/project/pylint/). [(#64)](https://github.com/XanaduAI/jet/pull/64)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,16 @@
-## Release 0.2.1 (development release)
+## Release 0.2.2 (development release)
+
+### Improvements
+
+* Python source files are now linted using [Flake8](https://flake8.pycqa.org/en/latest/). [(#64)](https://github.com/XanaduAI/jet/pull/64)
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+[Mikhail Andrenkov](https://github.com/Mandrenkov).
+
+## Release 0.2.1 (current release)
 
 ### New features since last release
 

--- a/python/.pylintrc
+++ b/python/.pylintrc
@@ -36,4 +36,4 @@ disable=duplicate-code,
         too-few-public-methods,
         too-many-branches,
         too-many-instance-attributes,
-        too-many-public-methods,
+        too-many-public-methods

--- a/python/.pylintrc
+++ b/python/.pylintrc
@@ -1,0 +1,39 @@
+[BASIC]
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^[tT]est
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=yes
+
+[TYPECHECK]
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=bindings,
+                lark,
+                numpy,
+                strawberryfields,
+                thewalrus.fock_gradients
+
+[MESSAGES CONTROL]
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once).
+disable=duplicate-code,
+        fixme,
+        invalid-name,
+        missing-module-docstring,
+        no-self-use,
+        too-few-public-methods,
+        too-many-branches,
+        too-many-instance-attributes,
+        too-many-public-methods,

--- a/python/Makefile
+++ b/python/Makefile
@@ -33,11 +33,13 @@ setup: $(.VENV_DIR)/touch
 .PHONY: format
 format: $(.VENV_DIR)/requirements.txt.touch
 ifdef check
-	$(.VENV_BIN)/black -l 100 --check jet tests
-	$(.VENV_BIN)/isort --profile black --check-only jet tests
+	$(.VENV_BIN)/black -l 100 --check jet tests xir
+	$(.VENV_BIN)/isort --profile black --check-only jet tests xir
+	$(.VENV_BIN)/flake8 --extend-ignore=E203,E501,W503 --show-source jet tests xir
 else
-	$(.VENV_BIN)/black -l 100 jet tests
-	$(.VENV_BIN)/isort --profile black jet tests
+	$(.VENV_BIN)/black -l 100 jet tests xir
+	$(.VENV_BIN)/isort --profile black jet tests xir
+	$(.VENV_BIN)/flake8 --extend-ignore=E203,E501,W503 --show-source jet tests xir
 endif
 
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -35,11 +35,11 @@ format: $(.VENV_DIR)/requirements.txt.touch
 ifdef check
 	$(.VENV_BIN)/black -l 100 --check jet tests xir
 	$(.VENV_BIN)/isort --profile black --check-only jet tests xir
-	$(.VENV_BIN)/flake8 --extend-ignore=E203,E501,W503 --show-source jet tests xir
+	$(.VENV_BIN)/pylint jet tests xir
 else
 	$(.VENV_BIN)/black -l 100 jet tests xir
 	$(.VENV_BIN)/isort --profile black jet tests xir
-	$(.VENV_BIN)/flake8 --extend-ignore=E203,E501,W503 --show-source jet tests xir
+	$(.VENV_BIN)/pylint jet tests xir
 endif
 
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -35,11 +35,11 @@ format: $(.VENV_DIR)/requirements.txt.touch
 ifdef check
 	$(.VENV_BIN)/black -l 100 --check jet tests xir
 	$(.VENV_BIN)/isort --profile black --check-only jet tests xir
-	$(.VENV_BIN)/pylint jet tests xir
+	$(.VENV_BIN)/pylint jet tests/*/*.py xir
 else
 	$(.VENV_BIN)/black -l 100 jet tests xir
 	$(.VENV_BIN)/isort --profile black jet tests xir
-	$(.VENV_BIN)/pylint jet tests xir
+	$(.VENV_BIN)/pylint jet tests/*/*.py xir
 endif
 
 

--- a/python/jet/__init__.py
+++ b/python/jet/__init__.py
@@ -4,14 +4,14 @@ quantum gates, states, and circuits.
 """
 
 # The existence of a Python binding is proof of its intention to be exposed.
-from .bindings import *
+from .bindings import *  # noqa: F403
 
 # The rest of the modules control their exports using `__all__`.
-from .circuit import *
-from .factory import *
-from .gate import *
-from .interpreter import *
-from .state import *
+from .circuit import *  # noqa: F403
+from .factory import *  # noqa: F403
+from .gate import *  # noqa: F403
+from .interpreter import *  # noqa: F403
+from .state import *  # noqa: F403
 
 # Grab the current Jet version from the C++ headers.
-__version__ = version()
+__version__ = version()  # noqa: F405

--- a/python/jet/__init__.py
+++ b/python/jet/__init__.py
@@ -3,15 +3,22 @@ with an interpreter for Xanadu IR (XIR) scripts and a set of classes to model
 quantum gates, states, and circuits.
 """
 
-# The existence of a Python binding is proof of its intention to be exposed.
-from .bindings import *  # noqa: F403
+from .bindings import (
+    PathInfo,
+    add_tensors,
+    conj,
+    contract_tensors,
+    reshape,
+    slice_index,
+    version,
+)
 
 # The rest of the modules control their exports using `__all__`.
-from .circuit import *  # noqa: F403
-from .factory import *  # noqa: F403
-from .gate import *  # noqa: F403
-from .interpreter import *  # noqa: F403
-from .state import *  # noqa: F403
+from .circuit import *
+from .factory import *
+from .gate import *
+from .interpreter import *
+from .state import *
 
 # Grab the current Jet version from the C++ headers.
-__version__ = version()  # noqa: F405
+__version__ = version()

--- a/python/jet/circuit.py
+++ b/python/jet/circuit.py
@@ -1,3 +1,4 @@
+"""Module containing the ``Operation``, ``Wire``, and ``Circuit`` classes."""
 from dataclasses import dataclass
 from typing import Iterator, Sequence, Union
 
@@ -207,8 +208,8 @@ class Circuit:
             if not 0 <= wire_id < num_wires:
                 raise ValueError(f"Wire ID {wire_id} falls outside the range [0, {num_wires}).")
 
-            elif wire_ids.count(wire_id) > 1:
+            if wire_ids.count(wire_id) > 1:
                 raise ValueError(f"Wire ID {wire_id} is specified more than once.")
 
-            elif self._wires[wire_id].closed:
+            if self._wires[wire_id].closed:
                 raise ValueError(f"Wire {wire_id} is closed.")

--- a/python/jet/factory.py
+++ b/python/jet/factory.py
@@ -1,3 +1,4 @@
+"""Module containing __init__() wrappers for the classes in jet.bindings."""
 from typing import Union
 
 import numpy as np
@@ -49,12 +50,14 @@ def TaskBasedContractor(*args, **kwargs) -> TaskBasedContractorType:
         Task-based contractor instance.
     """
     dtype = kwargs.pop("dtype", np.complex128)
+
     if np.dtype(dtype) == np.complex64:
         return TaskBasedContractorC64(*args, **kwargs)
-    elif np.dtype(dtype) == np.complex128:
+
+    if np.dtype(dtype) == np.complex128:
         return TaskBasedContractorC128(*args, **kwargs)
-    else:
-        raise TypeError(f"Data type '{dtype}' is not supported.")
+
+    raise TypeError(f"Data type '{dtype}' is not supported.")
 
 
 def Tensor(*args, **kwargs) -> TensorType:
@@ -69,12 +72,14 @@ def Tensor(*args, **kwargs) -> TensorType:
         Tensor instance.
     """
     dtype = kwargs.pop("dtype", np.complex128)
+
     if np.dtype(dtype) == np.complex64:
         return TensorC64(*args, **kwargs)
-    elif np.dtype(dtype) == np.complex128:
+
+    if np.dtype(dtype) == np.complex128:
         return TensorC128(*args, **kwargs)
-    else:
-        raise TypeError(f"Data type '{dtype}' is not supported.")
+
+    raise TypeError(f"Data type '{dtype}' is not supported.")
 
 
 def TensorNetwork(*args, **kwargs) -> TensorNetworkType:
@@ -90,12 +95,14 @@ def TensorNetwork(*args, **kwargs) -> TensorNetworkType:
         Tensor network instance.
     """
     dtype = kwargs.pop("dtype", np.complex128)
+
     if np.dtype(dtype) == np.complex64:
         return TensorNetworkC64(*args, **kwargs)
-    elif np.dtype(dtype) == np.complex128:
+
+    if np.dtype(dtype) == np.complex128:
         return TensorNetworkC128(*args, **kwargs)
-    else:
-        raise TypeError(f"Data type '{dtype}' is not supported.")
+
+    raise TypeError(f"Data type '{dtype}' is not supported.")
 
 
 def TensorNetworkFile(*args, **kwargs) -> TensorNetworkFileType:
@@ -111,12 +118,14 @@ def TensorNetworkFile(*args, **kwargs) -> TensorNetworkFileType:
         Tensor network file instance.
     """
     dtype = kwargs.pop("dtype", np.complex128)
+
     if np.dtype(dtype) == np.complex64:
         return TensorNetworkFileC64(*args, **kwargs)
-    elif np.dtype(dtype) == np.complex128:
+
+    if np.dtype(dtype) == np.complex128:
         return TensorNetworkFileC128(*args, **kwargs)
-    else:
-        raise TypeError(f"Data type '{dtype}' is not supported.")
+
+    raise TypeError(f"Data type '{dtype}' is not supported.")
 
 
 def TensorNetworkSerializer(*args, **kwargs) -> TensorNetworkSerializerType:
@@ -132,9 +141,11 @@ def TensorNetworkSerializer(*args, **kwargs) -> TensorNetworkSerializerType:
         Tensor network serializer instance.
     """
     dtype = kwargs.pop("dtype", np.complex128)
+
     if np.dtype(dtype) == np.complex64:
         return TensorNetworkSerializerC64(*args, **kwargs)
-    elif np.dtype(dtype) == np.complex128:
+
+    if np.dtype(dtype) == np.complex128:
         return TensorNetworkSerializerC128(*args, **kwargs)
-    else:
-        raise TypeError(f"Data type '{dtype}' is not supported.")
+
+    raise TypeError(f"Data type '{dtype}' is not supported.")

--- a/python/jet/gate.py
+++ b/python/jet/gate.py
@@ -1,3 +1,6 @@
+"""Module containing the ``Gate`` and ``GateFactory`` classes in addition to all
+``Gate`` subclasses.
+"""
 from abc import ABC, abstractmethod
 from cmath import exp
 from functools import lru_cache
@@ -169,7 +172,6 @@ class Gate(ABC):
     @abstractmethod
     def _data(self) -> np.ndarray:
         """Returns the matrix representation of this gate."""
-        pass
 
     def tensor(self, dtype: np.dtype = np.complex128) -> TensorType:
         """Returns the tensor representation of this gate.
@@ -195,8 +197,8 @@ class GateFactory:
     has been registered by a Gate subclass using the @register decorator.
     """
 
-    """Map that associates names with concrete Gate subclasses."""
     registry: Dict[str, type] = {}
+    """Map that associates names with concrete Gate subclasses."""
 
     @staticmethod
     def create(
@@ -256,6 +258,7 @@ class GateFactory:
 
         return wrapper
 
+    # pylint: disable=bad-staticmethod-argument
     @staticmethod
     def unregister(cls: type) -> None:
         """Unregisters a class type.
@@ -287,9 +290,11 @@ class Adjoint(Gate):
         )
 
     def _data(self):
+        # pylint: disable=protected-access
         return self._gate._data().conj().T
 
     def _validate_dimension(self, dim):
+        # pylint: disable=protected-access
         self._gate._validate_dimension(dim)
 
 
@@ -310,9 +315,11 @@ class Scale(Gate):
         )
 
     def _data(self):
+        # pylint: disable=protected-access
         return self._scalar * self._gate._data()
 
     def _validate_dimension(self, dim):
+        # pylint: disable=protected-access
         self._gate._validate_dimension(dim)
 
 

--- a/python/jet/interpreter.py
+++ b/python/jet/interpreter.py
@@ -1,3 +1,4 @@
+"""Module containing the Jet interpreter for XIR programs."""
 import random
 import warnings
 from copy import deepcopy
@@ -153,19 +154,19 @@ def run_xir_program(program: XIRProgram) -> List[Union[np.number, np.ndarray]]:
                     f"Statement '{stmt}' has a 'state' parameter which is not an array."
                 )
 
-            elif not all(0 <= entry < dimension for entry in state):
+            if not all(0 <= entry < dimension for entry in state):
                 raise ValueError(
                     f"Statement '{stmt}' has a 'state' parameter with at least "
                     f"one entry that falls outside the range [0, {dimension})."
                 )
 
-            elif len(state) != num_wires:
+            if len(state) != num_wires:
                 raise ValueError(
                     f"Statement '{stmt}' has a 'state' parameter with "
                     f"{len(state)} (!= {num_wires}) entries."
                 )
 
-            elif stmt.wires != tuple(range(num_wires)):
+            if stmt.wires != tuple(range(num_wires)):
                 raise ValueError(f"Statement '{stmt}' must be applied to [0 .. {num_wires - 1}].")
 
             output = _compute_amplitude(circuit=circuit, state=state)
@@ -190,13 +191,13 @@ def run_xir_program(program: XIRProgram) -> List[Union[np.number, np.ndarray]]:
                     f"references an undefined operator."
                 )
 
-            elif program.operators[operator]["params"]:
+            if program.operators[operator]["params"]:
                 raise ValueError(
                     f"Statement '{stmt}' has an 'observable' parameter which "
                     f"references a parameterized operator."
                 )
 
-            elif stmt.wires != tuple(range(num_wires)):
+            if stmt.wires != tuple(range(num_wires)):
                 raise ValueError(f"Statement '{stmt}' must be applied to [0 .. {num_wires - 1}].")
 
             observable = _generate_observable_from_operation_statements(
@@ -230,7 +231,7 @@ def _validate_xir_program_options(program: XIRProgram) -> None:
         if not isinstance(dimension, int):
             raise ValueError("Option 'dimension' must be an integer.")
 
-        elif dimension < 2:
+        if dimension < 2:
             raise ValueError("Option 'dimension' must be greater than one.")
 
     for option in sorted(options):
@@ -353,10 +354,9 @@ def _bind_statement_params(gate_signature_map: Dict[str, GateSignature], stmt: S
             raise ValueError(f"Statement '{stmt}' has the wrong number of parameters.")
         return {name: have_params[i] for (i, name) in enumerate(want_params)}
 
-    else:
-        if set(have_params) != set(want_params):
-            raise ValueError(f"Statement '{stmt}' has an invalid set of parameters.")
-        return {name: have_params[name] for name in want_params}
+    if set(have_params) != set(want_params):
+        raise ValueError(f"Statement '{stmt}' has an invalid set of parameters.")
+    return {name: have_params[name] for name in want_params}
 
 
 def _bind_statement_wires(gate_signature_map: Dict[str, GateSignature], stmt: Statement) -> Wires:
@@ -397,11 +397,11 @@ def _generate_observable_from_operation_statements(
     for stmt in stmts:
         try:
             scalar = float(stmt.pref)
-        except ValueError:
+        except ValueError as exc:
             raise ValueError(
                 f"Operator statement '{stmt}' has a prefactor ({stmt.pref}) "
                 f"which cannot be converted to a floating-point number."
-            )
+            ) from exc
 
         for gate_name, wire_id in stmt.terms:
             gate = GateFactory.create(gate_name, scalar=scalar)

--- a/python/jet/state.py
+++ b/python/jet/state.py
@@ -1,3 +1,4 @@
+"""Module containing the ``State`` class in addition to all ``State`` subclasses."""
 from abc import ABC, abstractmethod
 from typing import List, Optional, Sequence
 
@@ -81,12 +82,11 @@ class State(ABC):
 
     def __ne__(self, other) -> bool:
         """Reports whether this state is not equivalent to the given state."""
-        return not (self == other)
+        return not self == other
 
     @abstractmethod
     def _data(self) -> np.ndarray:
         """Returns the vector representation of this state."""
-        pass
 
     def tensor(self, dtype: np.dtype = np.complex128) -> TensorType:
         """Returns the tensor representation of this state.

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,6 @@
 black
 cmake>=3.14
+flake8
 isort>5
 pytest>=5,<6
 wheel

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
 black
 cmake>=3.14
-flake8
 isort>5
+pylint
 pytest>=5,<6
 wheel

--- a/python/tests/jet/conftest.py
+++ b/python/tests/jet/conftest.py
@@ -5,8 +5,9 @@ import jet
 
 @pytest.fixture
 def tensor_network():
+    """Returns a function that contructs a tensor network with three connected tensors."""
+
     def tensor_network_(dtype: str):
-        """Returns a tensor network with three tensors of the given type."""
         A = jet.Tensor(shape=[2, 2], indices=["i", "j"], data=[1, 1j, -1j, 1], dtype=dtype)
         B = jet.Tensor(shape=[2, 2], indices=["j", "k"], data=[1, 0, 0, 1], dtype=dtype)
         C = jet.Tensor(shape=[2], indices=["k"], data=[1, 0], dtype=dtype)

--- a/python/tests/jet/test_circuit.py
+++ b/python/tests/jet/test_circuit.py
@@ -22,6 +22,7 @@ class TestCircuit:
         assert list(circuit.wires) == [jet.Wire(i, 0, False) for i in range(4)]
         assert list(circuit.operations) == [jet.Operation(jet.Qubit(), [i]) for i in range(4)]
 
+    # pylint: disable=protected-access
     def test_validate_fake_wire(self, circuit):
         """Tests that a ValueError is raised when the wire ID validator is given
         a wire ID which does not exist in the circuit.
@@ -29,6 +30,7 @@ class TestCircuit:
         with pytest.raises(ValueError, match=r"Wire ID 4 falls outside the range \[0, 4\)."):
             circuit._validate_wire_ids(wire_ids=[4])
 
+    # pylint: disable=protected-access
     def test_validate_duplicate_wire(self, circuit):
         """Tests that a ValueError is raised when the wire ID validator is given
         a duplicate wire ID.
@@ -36,6 +38,7 @@ class TestCircuit:
         with pytest.raises(ValueError, match="Wire ID 0 is specified more than once."):
             circuit._validate_wire_ids(wire_ids=[0, 0])
 
+    # pylint: disable=protected-access
     def test_validate_closed_wire(self, circuit):
         """Tests that a ValueError is raised when the wire ID validator is given
         a wire ID associated with a closed wire.

--- a/python/tests/jet/test_gate.py
+++ b/python/tests/jet/test_gate.py
@@ -105,6 +105,7 @@ class TestGateFactory:
         """Tests that a KeyError is raised when an existing key is registered."""
         with pytest.raises(KeyError, match=r"The names {'X'} already exist in the gate registry\."):
 
+            # pylint: disable=missing-class-docstring
             @jet.GateFactory.register(names=["X", "O"])
             class TicTacToeGate(jet.Gate):
                 pass
@@ -114,6 +115,7 @@ class TestGateFactory:
     def test_register_duplicate_keys(self):
         """Tests that a Gate subclass can be registered with duplicate keys."""
 
+        # pylint: disable=missing-class-docstring
         @jet.GateFactory.register(names=["n", "N", "no", "NO", "No"])
         class CancelGate(jet.Gate):
             pass

--- a/python/tests/jet/test_gate.py
+++ b/python/tests/jet/test_gate.py
@@ -1,4 +1,3 @@
-from itertools import chain
 from math import pi, sqrt
 
 import numpy as np

--- a/python/tests/jet/test_interpreter.py
+++ b/python/tests/jet/test_interpreter.py
@@ -400,7 +400,10 @@ def test_run_xir_program_with_amplitude_statements(program, want_result):
         ),
         (
             xir.parse_script("CNOT | [0, 1]; amplitude(state: [0, 1]) | [1, 0];"),
-            r"Statement 'amplitude\(state: \[0, 1\]\) \| \[1, 0\]' must be applied to \[0 \.\. 1\]\.",
+            (
+                r"Statement 'amplitude\(state: \[0, 1\]\) \| \[1, 0\]' "
+                r"must be applied to \[0 \.\. 1\]\."
+            ),
         ),
     ],
 )

--- a/python/tests/jet/test_pathinfo.py
+++ b/python/tests/jet/test_pathinfo.py
@@ -21,7 +21,7 @@ class TestPathInfo:
 
         id_a = tn.add_tensor(jet.Tensor(), ["A"])
         id_b = tn.add_tensor(jet.Tensor(), ["B"])
-        id_c = tn.add_tensor(jet.Tensor(), ["C"])
+        tn.add_tensor(jet.Tensor(), ["C"])
 
         path = [(id_a, id_b)]
 

--- a/python/tests/jet/test_state.py
+++ b/python/tests/jet/test_state.py
@@ -58,7 +58,7 @@ class TestState:
         """Tests that two different states are not equal."""
         state0 = MockState()
         state1 = MockState()
-        state1._data = lambda: np.array([0, 0, 1])
+        state1._data = lambda: np.array([0, 0, 1])  # pylint: disable=protected-access
         assert state0 != state1
 
 

--- a/python/tests/jet/test_tensor.py
+++ b/python/tests/jet/test_tensor.py
@@ -3,6 +3,7 @@ import pytest
 import jet
 
 
+# pylint: disable=unused-argument
 @pytest.mark.parametrize("dtype", ["complex64", "complex128"])
 class TestTensor:
     def test_default_constructor(self, dtype):

--- a/python/tests/jet/test_tensor_network.py
+++ b/python/tests/jet/test_tensor_network.py
@@ -9,7 +9,7 @@ class TestTensorNetwork:
         tn = jet.TensorNetwork(dtype=dtype)
 
         with pytest.raises(IndexError):
-            tn.nodes[0]
+            tn.nodes[0]  # pylint: disable=pointless-statement
 
         assert tn.num_tensors == 0
         assert tn.path == []

--- a/python/tests/jet/test_tensor_network.py
+++ b/python/tests/jet/test_tensor_network.py
@@ -9,7 +9,7 @@ class TestTensorNetwork:
         tn = jet.TensorNetwork(dtype=dtype)
 
         with pytest.raises(IndexError):
-            node = tn.nodes[0]
+            tn.nodes[0]
 
         assert tn.num_tensors == 0
         assert tn.path == []

--- a/python/tests/xir/test_decimal_complex.py
+++ b/python/tests/xir/test_decimal_complex.py
@@ -132,10 +132,10 @@ class TestDecimalComplex:
 
         match = r"Cannot use > with complex numbers"
         with pytest.raises(TypeError, match=match):
-            c > term
+            c > term  # pylint: disable=pointless-statement
 
         with pytest.raises(TypeError, match=match):
-            term < c
+            term < c  # pylint: disable=pointless-statement
 
     @pytest.mark.parametrize("term", [2, 3j, "2", Decimal("1"), -4.3])
     def test_less_than(self, term):
@@ -144,10 +144,10 @@ class TestDecimalComplex:
 
         match = r"Cannot use < with complex numbers"
         with pytest.raises(TypeError, match=match):
-            c < term
+            c < term  # pylint: disable=pointless-statement
 
         with pytest.raises(TypeError, match=match):
-            term > c
+            term > c  # pylint: disable=pointless-statement
 
     @pytest.mark.parametrize("term", [2, 3j, "2", Decimal("1"), -4.3])
     def test_greater_equal_than(self, term):
@@ -156,10 +156,10 @@ class TestDecimalComplex:
 
         match = r"Cannot use >= with complex numbers"
         with pytest.raises(TypeError, match=match):
-            c >= term
+            c >= term  # pylint: disable=pointless-statement
 
         with pytest.raises(TypeError, match=match):
-            term <= c
+            term <= c  # pylint: disable=pointless-statement
 
     @pytest.mark.parametrize("term", [2, 3j, "2", Decimal("1"), -4.3])
     def test_less_equal_than(self, term):
@@ -168,10 +168,10 @@ class TestDecimalComplex:
 
         match = r"Cannot use <= with complex numbers"
         with pytest.raises(TypeError, match=match):
-            c <= term
+            c <= term  # pylint: disable=pointless-statement
 
         with pytest.raises(TypeError, match=match):
-            term >= c
+            term >= c  # pylint: disable=pointless-statement
 
     @pytest.mark.parametrize(
         "t, match",
@@ -184,7 +184,15 @@ class TestDecimalComplex:
             (float, r"argument must be a string or a number"),
             (range, r"object cannot be interpreted as an integer"),
             (bytes, r"cannot convert 'DecimalComplex' object to bytes"),
-            (bytearray, r"cannot convert 'DecimalComplex' object to bytearray"),
+            (
+                bytearray,
+                (
+                    # Python 3.7
+                    r"object is not iterable|"
+                    # Python 3.8+
+                    r"cannot convert 'DecimalComplex' object to bytearray"
+                ),
+            ),
             (int, r"argument must be a string, a bytes-like object or a number"),
             (memoryview, r"a bytes-like object is required"),
         ],

--- a/python/tests/xir/test_io.py
+++ b/python/tests/xir/test_io.py
@@ -41,17 +41,17 @@ def create_xir_prog(
     return irprog
 
 
-def create_sf_prog(num_of_wires: int, ops: List[Tuple]):
+def create_sf_prog(num_of_wires: int, ops_: List[Tuple]):
     """Create a Strawberry Fields program"""
     prog = sf.Program(num_of_wires)
 
     with prog.context as q:
-        for gate, params, wires in ops:
+        for gate, params, wires in ops_:
             regrefs = [q[w] for w in wires]
             if len(params) == 0:
-                gate | regrefs
+                gate | regrefs  # pylint: disable=pointless-statement
             else:
-                gate(*params) | regrefs
+                gate(*params) | regrefs  # pylint: disable=expression-not-assigned
 
     return prog
 
@@ -115,7 +115,7 @@ class TestStrawberryFieldsToXIR:
 
     def test_empty_sfprogram(self):
         """Test that converting from an empty SF program works"""
-        sfprog = create_sf_prog(num_of_wires=2, ops=[])
+        sfprog = create_sf_prog(num_of_wires=2, ops_=[])
         irprog = to_xir(sfprog)
 
         assert irprog.version == "0.1.0"
@@ -136,7 +136,7 @@ class TestStrawberryFieldsToXIR:
             (ops.Vac, [], (0,)),
         ]
 
-        sfprog = create_sf_prog(num_of_wires=2, ops=circuit_data)
+        sfprog = create_sf_prog(num_of_wires=2, ops_=circuit_data)
         irprog = to_xir(sfprog, add_decl=add_decl)
 
         stmt = irprog.statements[0]
@@ -164,7 +164,7 @@ class TestStrawberryFieldsToXIR:
             (ops.Sgate, [Decimal("0.3")], (1,)),
         ]
 
-        sfprog = create_sf_prog(num_of_wires=2, ops=circuit_data)
+        sfprog = create_sf_prog(num_of_wires=2, ops_=circuit_data)
         irprog = to_xir(sfprog, add_decl=add_decl)
 
         stmts = irprog.statements

--- a/python/tests/xir/test_program.py
+++ b/python/tests/xir/test_program.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 """Unit tests for the program class"""
 
 from decimal import Decimal
@@ -443,17 +444,20 @@ class TestXIRProgram:
         program.add_variable("theta")
         assert set(program.variables) == {"theta", "phi"}
 
+    # pylint: disable=protected-access
     @pytest.mark.parametrize("version", ["4.2.0", "0.3.0"])
     def test_validate_version(self, version):
         """Test that a correct version passes validation."""
         XIRProgram._validate_version(version)
 
+    # pylint: disable=protected-access
     @pytest.mark.parametrize("version", [42, 0.2, True, object()])
     def test_validate_version_with_wrong_type(self, version):
         """Test that an exception is raised when a version has the wrong type."""
         with pytest.raises(TypeError, match=r"Version '[^']*' must be a string"):
             XIRProgram._validate_version(version)
 
+    # pylint: disable=protected-access
     @pytest.mark.parametrize("version", ["", "abc", "4.2", "1.2.3-alpha", "0.1.2.3"])
     def test_validate_version_with_wrong_format(self, version):
         """Test that an exception is raised when a version has the wrong format."""

--- a/python/tests/xir/test_program.py
+++ b/python/tests/xir/test_program.py
@@ -254,7 +254,7 @@ class TestXIRProgram:
     def test_repr(self):
         """Test that the string representation of an XIR program has the correct format."""
         program = XIRProgram(version="1.2.3")
-        assert repr(program) == f"<XIRProgram: version=1.2.3>"
+        assert repr(program) == "<XIRProgram: version=1.2.3>"
 
     def test_add_called_function(self, program):
         """Tests that called functions can be added to an XIR program."""
@@ -365,7 +365,7 @@ class TestXIRProgram:
         program.add_include("algorithm")
         assert list(program.includes) == ["complex", "algorithm"]
 
-    def test_add_gate_with_same_name(self, program):
+    def test_add_include_with_same_name(self, program):
         """Tests that a warning is issued when two identical includes are added
         to an XIR program.
         """

--- a/python/xir/__init__.py
+++ b/python/xir/__init__.py
@@ -1,6 +1,6 @@
-from .decimal_complex import DecimalComplex  # noqa: F401
-from .parser import XIRTransformer, xir_parser  # noqa: F401
-from .program import GateDeclaration, OperatorStmt, Statement, XIRProgram  # noqa: F401
+from .decimal_complex import DecimalComplex
+from .parser import XIRTransformer, xir_parser
+from .program import GateDeclaration, OperatorStmt, Statement, XIRProgram
 
 
 def parse_script(circuit: str, **kwargs) -> XIRProgram:

--- a/python/xir/__init__.py
+++ b/python/xir/__init__.py
@@ -1,6 +1,6 @@
-from .decimal_complex import DecimalComplex
-from .parser import XIRTransformer, xir_parser
-from .program import GateDeclaration, OperatorStmt, Statement, XIRProgram
+from .decimal_complex import DecimalComplex  # noqa: F401
+from .parser import XIRTransformer, xir_parser  # noqa: F401
+from .program import GateDeclaration, OperatorStmt, Statement, XIRProgram  # noqa: F401
 
 
 def parse_script(circuit: str, **kwargs) -> XIRProgram:

--- a/python/xir/decimal_complex.py
+++ b/python/xir/decimal_complex.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 from decimal import Decimal
 from numbers import Complex
-from typing import Union, Callable
+from typing import Callable, Union
 
 
 def convert_input(func: Callable) -> Callable:
@@ -37,7 +37,9 @@ class DecimalComplex(Complex):
             to ``0.0`` if not input.
     """
 
-    def __init__(self, real: Union[str, Decimal] = "0.0", imag: Union[str, Decimal] = "0.0") -> None:
+    def __init__(
+        self, real: Union[str, Decimal] = "0.0", imag: Union[str, Decimal] = "0.0"
+    ) -> None:
         self._real = Decimal(real)
         self._imag = Decimal(imag)
 

--- a/python/xir/decimal_complex.py
+++ b/python/xir/decimal_complex.py
@@ -15,10 +15,10 @@ def convert_input(func: Callable) -> Callable:
     def convert_wrapper(self, c: Union[Decimal, Complex]) -> DecimalComplex:
         if isinstance(c, DecimalComplex):
             return func(self, c)
-        elif isinstance(c, Decimal):
+        if isinstance(c, Decimal):
             c = DecimalComplex(c)
             return func(self, c)
-        elif isinstance(c, Complex):
+        if isinstance(c, Complex):
             c = DecimalComplex(str(c.real), str(c.imag))
             return func(self, c)
 
@@ -70,12 +70,14 @@ class DecimalComplex(Complex):
     def __rmul__(self, c: Union[Decimal, Complex]) -> DecimalComplex:
         return self * c
 
+    # pylint: disable=missing-function-docstring
     @convert_input
     def __div__(self, c: Union[Decimal, Complex]) -> DecimalComplex:
         real = (self.real * c.real + self.imag * c.imag) / (c.real ** 2 + c.imag ** 2)
         imag = (self.imag * c.real - self.real * c.imag) / (c.real ** 2 + c.imag ** 2)
         return DecimalComplex(real, imag)
 
+    # pylint: disable=missing-function-docstring
     @convert_input
     def __rdiv__(self, c: Union[Decimal, Complex]) -> DecimalComplex:
         return c / self
@@ -88,6 +90,7 @@ class DecimalComplex(Complex):
     def __rtruediv__(self, c: Union[Decimal, Complex]) -> DecimalComplex:
         return c / self
 
+    # pylint: disable=missing-function-docstring
     def __floordiv__(self, _: Union[Decimal, Complex]) -> DecimalComplex:
         raise TypeError("Cannot take floor of DecimalComplex")
 
@@ -143,6 +146,7 @@ class DecimalComplex(Complex):
         return float(self.real) + float(self.imag) * 1j
 
     def _not_implemented(self, op):
+        """Raises a TypeError for the given (unimplemented) operation."""
         raise TypeError(f"Cannot use {op} with complex numbers")
 
     def __hash__(self):

--- a/python/xir/interfaces/__init__.py
+++ b/python/xir/interfaces/__init__.py
@@ -1,1 +1,1 @@
-from .strawberryfields_io import to_program, to_xir
+from .strawberryfields_io import to_program, to_xir  # noqa: F401

--- a/python/xir/interfaces/__init__.py
+++ b/python/xir/interfaces/__init__.py
@@ -1,1 +1,1 @@
-from .strawberryfields_io import to_program, to_xir  # noqa: F401
+from .strawberryfields_io import to_program, to_xir

--- a/python/xir/interfaces/strawberryfields_io.py
+++ b/python/xir/interfaces/strawberryfields_io.py
@@ -62,7 +62,7 @@ def to_program(xir, **kwargs):
             else:
                 gate | regrefs  # pylint:disable=expression-not-assigned,pointless-statement
 
-    prog._target = kwargs.get("target")
+    prog._target = kwargs.get("target")  # pylint: disable=protected-access
 
     if kwargs.get("shots") is not None:
         prog.run_options["shots"] = kwargs.get("shots")

--- a/python/xir/parser.py
+++ b/python/xir/parser.py
@@ -24,7 +24,7 @@ with p.open("r") as _f:
 
 xir_parser = Lark(ir_grammar, start="program", parser="lalr")
 
-
+# pylint: disable=missing-function-docstring
 class XIRTransformer(Transformer):
     """Transformer for processing the Lark parse tree.
 
@@ -46,7 +46,7 @@ class XIRTransformer(Transformer):
         super().__init__(self, *args, **kwargs)
 
     @property
-    def eval_pi(self) -> bool:
+    def eval_pi(self) -> bool:  # pylint: disable=used-before-assignment
         """Reports whether pi is evaluated and stored as a float."""
         return self._eval_pi
 
@@ -79,7 +79,10 @@ class XIRTransformer(Transformer):
         self._program.add_include(file_name[0])
 
     def circuit(self, args):
-        """Main circuit containing all the gate statements. Should be empty after tree has been parsed from the leaves up, and all statemtents been passed to the program."""
+        """Main circuit containing all the gate statements. Should be empty after
+        the tree has been parsed from the leaves up and all statetents have been
+        passed to the program.
+        """
         # assert all stmts are handled
         assert all(a is None for a in args)
 

--- a/python/xir/parser.py
+++ b/python/xir/parser.py
@@ -2,6 +2,7 @@
 import math
 from decimal import Decimal
 from pathlib import Path
+from typing import Union
 
 from lark import Lark, Transformer
 
@@ -66,7 +67,7 @@ class XIRTransformer(Transformer):
             XIRProgram: program containing all parsed data
         """
         # assert all stmts are handled
-        assert all(a == None for a in args)
+        assert all(a is None for a in args)
         return self._program
 
     opdecl = list
@@ -80,7 +81,7 @@ class XIRTransformer(Transformer):
     def circuit(self, args):
         """Main circuit containing all the gate statements. Should be empty after tree has been parsed from the leaves up, and all statemtents been passed to the program."""
         # assert all stmts are handled
-        assert all(a == None for a in args)
+        assert all(a is None for a in args)
 
     def script_options(self, args):
         """Script level options."""
@@ -115,12 +116,16 @@ class XIRTransformer(Transformer):
         """Tuple with wires and identifier"""
         return "wires", tuple(w)
 
+    def FALSE_(self, _) -> bool:
+        return False
+
+    def TRUE_(self, _) -> bool:
+        return True
+
     option = tuple
     options_dict = dict
     params = list
     array = list
-    FALSE_ = lambda self, _: False
-    TRUE_ = lambda self, _: True
 
     ADJOINT = str
     CTRL = str
@@ -215,7 +220,7 @@ class XIRTransformer(Transformer):
         stmt_options = {
             "ctrl_wires": tuple(sorted(ctrl_wires, key=hash)),
             "adjoint": adjoint,
-            "use_floats": self.use_floats
+            "use_floats": self.use_floats,
         }
         return Statement(name, params, wires, **stmt_options)
 
@@ -290,4 +295,5 @@ class XIRTransformer(Transformer):
             return -args[0]
         return "-" + str(args[0])
 
-    PI = lambda self, _: "PI" if not self._eval_pi else Decimal(str(math.pi))
+    def PI(self, _) -> Union[str, Decimal]:
+        return "PI" if not self._eval_pi else Decimal(str(math.pi))

--- a/python/xir/program.py
+++ b/python/xir/program.py
@@ -57,13 +57,7 @@ class Statement:
             and ``DecimalComplex`` objects. Defaults to ``True``.
     """
 
-    def __init__(
-            self,
-            name: str,
-            params: Params,
-            wires: Sequence[Wire],
-            **kwargs
-        ):
+    def __init__(self, name: str, params: Params, wires: Sequence[Wire], **kwargs):
         self._name = name
         self._params = params
         self._wires = wires

--- a/python/xir/program.py
+++ b/python/xir/program.py
@@ -148,20 +148,24 @@ class OperatorStmt:
 
     @property
     def pref(self) -> Union[Decimal, float, int, str]:
+        """Returns the prefactor of this operator statement."""
         if isinstance(self._pref, Decimal) and self.use_floats:
             return float(self._pref)
         return self._pref
 
     @property
     def terms(self) -> List:
+        """Returns the terms in this operator statement."""
         return self._terms
 
     @property
     def use_floats(self) -> bool:
+        """Returns the float setting of this operator statement."""
         return self._use_floats
 
     @property
     def wires(self) -> Tuple:
+        """Returns the wires this operator statement is applied to."""
         return tuple({t[1] for t in self.terms})
 
 
@@ -442,7 +446,7 @@ class XIRProgram:
         """
         if include in self._includes:
             warnings.warn(f"Module '{include}' is already included. Skipping include.")
-            return None
+            return
 
         self._includes.append(include)
 

--- a/python/xir/utils.py
+++ b/python/xir/utils.py
@@ -121,7 +121,7 @@ def is_equal(circuit_1: str, circuit_2: str, check_decl: bool = True):
             if is_decl(clist_1[i - 1]):
                 j -= 1
                 continue
-            elif is_decl(clist_2[j - 1]):
+            if is_decl(clist_2[j - 1]):
                 i -= 1
                 continue
 


### PR DESCRIPTION
**Context:**
[PyLint](https://pypi.org/project/pylint/) is a linter which catches mistakes commonly made by Python programmers; PyLint is preferred to [Flake8](https://flake8.pycqa.org/en/latest/) since the former is the standard used by other Xanadu OSS projects (thanks to @josh146 for pointing this out).

**Description of the Change:**
- The "format" target of the Python makefile now invokes `pylint` (in addition to `black` and `isort`).
- The XIR source directory is now included in the scope of the Python formatters.

**Benefits:**
- Python source files with unused variables, imports, missing docstrings, etc. will be rejected by the CI pipeline.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.