### PR TITLE
Pip install from GitHub repository

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 * Python source files are now linted using [PyLint](https://pypi.org/project/pylint/). [(#64)](https://github.com/XanaduAI/jet/pull/64)
 
+### Documentation
+
+* The `pip install` instructions no longer reference a missing PyPI package. [(#66)](https://github.com/XanaduAI/jet/pull/66)
+
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ as well as all dependencies, can be done using pip:
 
 .. code-block:: bash
 
-    pip install git+https://github.com/XanaduAI/jet
+    pip install git+https://github.com/XanaduAI/jet#egg=quantum-jet
 
 To build the Jet Python distribution locally, a BLAS library with a CBLAS
 interface and a C++ compiler with C++17 support is required.  Simply run

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ as well as all dependencies, can be done using pip:
 
 .. code-block:: bash
 
-    pip install quantum-jet
+    pip install git+https://github.com/XanaduAI/jet
 
 To build the Jet Python distribution locally, a BLAS library with a CBLAS
 interface and a C++ compiler with C++17 support is required.  Simply run

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,7 +133,7 @@ author = "Xanadu Inc."
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = "0.2.1"
+release = "0.2.2-dev"
 
 # The short X.Y version.
 version = re.match(r"^(\d+\.\d+)", release).expand(r"\1")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,7 +133,7 @@ author = "Xanadu Inc."
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = "0.2.2-dev"
+from jet import __version__ as release
 
 # The short X.Y version.
 version = re.match(r"^(\d+\.\d+)", release).expand(r"\1")

--- a/include/jet/Version.hpp
+++ b/include/jet/Version.hpp
@@ -11,7 +11,7 @@ constexpr size_t MAJOR_VERSION = 0;
 constexpr size_t MINOR_VERSION = 2;
 
 /// Patch version number of Jet.
-constexpr size_t PATCH_VERSION = 1;
+constexpr size_t PATCH_VERSION = 2;
 
 /**
  * @brief Returns the current Jet version.

--- a/python/xir/interfaces/strawberryfields_io.py
+++ b/python/xir/interfaces/strawberryfields_io.py
@@ -101,7 +101,7 @@ def to_xir(prog, **kwargs):
                 output_decl = Declaration(name, declaration_type="output")
                 xir.add_declaration("output", output_decl)
 
-            params = dict()
+            params = {}
             # special case to take into account 'select' keyword argument
             if cmd.op.select is not None:
                 params["select"] = cmd.op.select

--- a/python/xir/program.py
+++ b/python/xir/program.py
@@ -39,7 +39,7 @@ def get_floats(params: Params) -> Params:
                 params_with_floats.append(p)
 
     elif isinstance(params, Dict):
-        params_with_floats = dict()
+        params_with_floats = {}
         for k, v in params.items():
             if isinstance(v, DecimalComplex):
                 params_with_floats[k] = complex(v)

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,8 @@ with open("include/jet/Version.hpp", "r") as f:
 
 requirements = [
     "lark-parser>=0.11.0",
-    "numpy>=1.0.0",
+    # Necessary until https://github.com/numba/numba/issues/7176 is resolved.
+    "numpy<1.21.0",
     "StrawberryFields==0.18.0",
     "thewalrus>=0.15.0",
 ]


### PR DESCRIPTION
**Context:**
The current Python installation instructions in the README do not work since Jet has not been published to PyPI yet.

**Description of the Change:**
* The `pip install` command in the README has been updated to use the GitHub repository.
* The version of the Jet C++ library has been incremented to 0.2.2 (and the Python version to 0.2.2-dev).

**Benefits:**
* The README instructions are more accurate.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.