### PR TITLE
Mutator for Tensor data

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,15 +1,24 @@
 ## Release 0.2.2 (development release)
 
+### New features since last release
+
+* The `Tensor` class now has a public function for replacing its data. [(#68)](https://github.com/XanaduAI/jet/pull/68)
+
 ### Improvements
 
 * Python wheels are now built in CI for Linux and MacOS. [(#65)](https://github.com/XanaduAI/jet/pull/65)
 
 * Python source files are now linted using [PyLint](https://pypi.org/project/pylint/). [(#64)](https://github.com/XanaduAI/jet/pull/64)
 
+### Bug Fixes
+
+* The `CudaTensor` class now accepts a data vector by reference in its constructor. [(#68)](https://github.com/XanaduAI/jet/pull/68)
+
 ### Documentation
 
-* The `pip install` instructions no longer reference a missing PyPI package. [(#66)](https://github.com/XanaduAI/jet/pull/66)
+* The `Tensor::GetValue()` and `Tensor::SetValue()` Doxygen comments now use LaTeX formulas. [(#68)](https://github.com/XanaduAI/jet/pull/68)
 
+* The `pip install` instructions no longer reference a missing PyPI package. [(#66)](https://github.com/XanaduAI/jet/pull/66)
 
 ### Contributors
 

--- a/include/jet/CudaTensor.hpp
+++ b/include/jet/CudaTensor.hpp
@@ -178,7 +178,7 @@ template <class T = cuComplex, int CUDA_DEVICE = 0> class CudaTensor {
     }
 
     CudaTensor(const std::vector<std::string> &indices,
-               const std::vector<size_t> &shape, const std::vector<T> data)
+               const std::vector<size_t> &shape, const std::vector<T> &data)
         : CudaTensor(indices, shape)
     {
         CudaScopedDevice ctx(CUDA_DEVICE);

--- a/include/jet/Tensor.hpp
+++ b/include/jet/Tensor.hpp
@@ -289,6 +289,20 @@ template <class T = std::complex<float>> class Tensor {
     }
 
     /**
+     * @brief Sets the data of a `%Tensor`.
+     *
+     * @param data Data of the `%Tensor` in row-major order.
+     *
+     * @exception Jet::Exception Data has the wrong size.
+     */
+    void SetData(const std::vector<T> &data)
+    {
+        JET_ABORT_IF_NOT(data.size() == GetSize(),
+                         "Data size does not match tensor size.");
+        Utilities::FastCopy(data, data_);
+    }
+
+    /**
      * @brief Returns the `%Tensor` data in row-major order.
      *
      * @return Vector of complex data values.

--- a/include/jet/Tensor.hpp
+++ b/include/jet/Tensor.hpp
@@ -262,9 +262,11 @@ template <class T = std::complex<float>> class Tensor {
     }
 
     /**
-     * @brief Sets the `%Tensor` data value at the given n-dimensional index.
+     * @brief Sets the `%Tensor` data value at the given \f$n\f$-dimensional
+     *        index.
      *
-     * @param indices n-dimensional `%Tensor` data index in row-major order.
+     * @param indices \f$n\f$-dimensional `%Tensor` data index in row-major
+     *                order.
      * @param value Data value to set at given index.
      */
     void SetValue(const std::vector<size_t> &indices, const T &value)

--- a/include/jet/Tensor.hpp
+++ b/include/jet/Tensor.hpp
@@ -298,7 +298,7 @@ template <class T = std::complex<float>> class Tensor {
     void SetData(const std::vector<T> &data)
     {
         JET_ABORT_IF_NOT(data.size() == GetSize(),
-                         "Data size does not match tensor size.");
+                         "Size of data and tensor do not match.");
         Utilities::FastCopy(data, data_);
     }
 

--- a/include/jet/Tensor.hpp
+++ b/include/jet/Tensor.hpp
@@ -275,9 +275,11 @@ template <class T = std::complex<float>> class Tensor {
     }
 
     /**
-     * @brief Returns the `%Tensor` data value at the given n-dimensional index.
+     * @brief Returns the `%Tensor` data value at the given \f$n\f$-dimensional
+     *        index.
      *
-     * @param indices n-dimensional `%Tensor` data index in row-major order.
+     * @param indices \f$n\f$-dimensional `%Tensor` data index in row-major
+     *                order.
      *
      * @returns Complex data value.
      */

--- a/include/jet/Tensor.hpp
+++ b/include/jet/Tensor.hpp
@@ -315,7 +315,7 @@ template <class T = std::complex<float>> class Tensor {
      *
      * @return Number of data elements.
      */
-    size_t GetSize() const { return Jet::Utilities::ShapeToSize(shape_); }
+    size_t GetSize() const { return data_.size(); }
 
     /**
      * @brief Returns a single scalar value from the `%Tensor` object.

--- a/python/src/Tensor.hpp
+++ b/python/src/Tensor.hpp
@@ -97,15 +97,15 @@ Args:
         // Properties
         // ---------------------------------------------------------------------
 
+        .def_property("data", &tensor_t::GetData, &tensor_t::SetData,
+                      "Complex data values in row-major order.")
+
         .def_property("shape", &tensor_t::GetShape, &tensor_t::SetShape,
                       "List containing the dimension of each tensor index.")
 
         .def_property_readonly("index_to_dimension_map",
                                &tensor_t::GetIndexToDimension,
                                "Mapping from index labels to dimension sizes.")
-
-        .def_property_readonly("data", &tensor_t::GetData,
-                               "Complex data values in row-major order.")
 
         .def_property_readonly("indices", &tensor_t::GetIndices,
                                "List of index labels.")

--- a/python/tests/jet/test_tensor.py
+++ b/python/tests/jet/test_tensor.py
@@ -44,6 +44,12 @@ class TestTensor:
         tensor_2 = jet.Tensor(other=tensor_1, dtype=dtype)
         assert tensor_1 == tensor_2
 
+    def test_set_data(self, dtype):
+        """Tests that the data of a tensor can be modified."""
+        tensor = jet.Tensor(shape=[2, 3], indices=["i", "j"], data=range(6), dtype=dtype)
+        tensor.data = [9, 8, 7, 6, 5, 4]
+        assert tensor.data == [9, 8, 7, 6, 5, 4]
+
     def test_set_shape(self, dtype):
         """Tests that the shape of a tensor can be modified."""
         tensor = jet.Tensor(shape=[1, 2, 3, 4], dtype=dtype)

--- a/test/Test_Tensor.cpp
+++ b/test/Test_Tensor.cpp
@@ -176,14 +176,14 @@ TEST_CASE("Tensor::SetData", "[Tensor]")
     {
         const Data data(2, 2);
         CHECK_THROWS_WITH(tensor.SetData(data),
-                          Contains("Data size does not match tensor size."));
+                          Contains("Size of data and tensor do not match."));
     }
 
     SECTION("Data is too large")
     {
         const Data data(8, 8);
         CHECK_THROWS_WITH(tensor.SetData(data),
-                          Contains("Data size does not match tensor size."));
+                          Contains("Size of data and tensor do not match."));
     }
 }
 

--- a/test/Test_Tensor.cpp
+++ b/test/Test_Tensor.cpp
@@ -159,6 +159,34 @@ TEST_CASE("Tensor::GetIndices", "[Tensor]")
     }
 }
 
+TEST_CASE("Tensor::SetData", "[Tensor]")
+{
+    using namespace Catch::Matchers;
+
+    Tensor tensor({"i", "j"}, {2, 3}, {0, 1, 2, 3, 4, 5});
+
+    SECTION("Data is the correct size")
+    {
+        const Data data(6, 6);
+        tensor.SetData(data);
+        CHECK(tensor.GetData() == data);
+    }
+
+    SECTION("Data is too small")
+    {
+        const Data data(2, 2);
+        CHECK_THROWS_WITH(tensor.SetData(data),
+                          Contains("Data size does not match tensor size."));
+    }
+
+    SECTION("Data is too large")
+    {
+        const Data data(8, 8);
+        CHECK_THROWS_WITH(tensor.SetData(data),
+                          Contains("Data size does not match tensor size."));
+    }
+}
+
 TEST_CASE("Tensor::GetData", "[Tensor]")
 {
     SECTION("Data: default")


### PR DESCRIPTION
**Context:**
Currently, there is no way to replace the data of a tensor in a tensor network using the Python bindings. This has been identified as a potential performance bottleneck when modelling parameterized quantum circuits using Jet.

**Description of the Change:**
* Implemented the `Tensor::SetData()` function which replaces the data of a tensor.
* Upgraded the `Tensor*.data` attribute of the Python package so that it is no longer read-only.
* Changed the data vector parameter of a `CudaTensor` constructor to be passed by reference.
* Modified `Tensor::GetSize()` to use the `std::vector::size` property of the tensor data (this is more efficient).

**Benefits:**
* The performance of a `CudaTensor` constructor and `Tensor::GetSize()` are slightly better.
* It is possible to replace the data of a specific tensor in a tensor network.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.