### PR TITLE
Install CMake on Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,6 @@ version: 2
 build:
   image: latest
   apt_packages:
-    - cmake
     - doxygen
     - graphviz
     - libblas-dev
@@ -15,6 +14,7 @@ python:
   install:
     - requirements: docs/requirements.txt
     - requirements: python/requirements.txt
+    - requirements: python/requirements-dev.txt
     - method: pip
       path: .
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,11 +3,12 @@ version: 2
 build:
   image: latest
   apt_packages:
+    - cmake
+    - doxygen
+    - graphviz
     - libblas-dev
     - python3.7-dev
     - python3-wheel
-    - doxygen
-    - graphviz
 
 python:
   version: 3.7


### PR DESCRIPTION
**Context:**
The image used by Read the Docs to build the Sphinx documentation no longer includes CMake.

**Description of the Change:**
- Modified the Read the Docs configuration to install CMake using pip.

**Benefits:**
- Read the Docs can build the Jet documentation.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.