### PR TITLE
Fix README for PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ as well as all dependencies, can be done using pip:
 
 .. code-block:: bash
 
-    pip install git+https://github.com/XanaduAI/jet#egg=quantum-jet
+    pip install quantum-jet
 
 To build the Jet Python distribution locally, a BLAS library with a CBLAS
 interface and a C++ compiler with C++17 support is required.  Simply run

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,7 @@
-.. raw:: html
-
-    <p align="center">
-        <img width="250" alt="Jet" src="https://raw.githubusercontent.com/XanaduAI/jet/main/docs/_static/jet_title.svg">
-    </p>
+.. image:: https://raw.githubusercontent.com/XanaduAI/jet/main/docs/_static/jet_title.svg
+    :alt: Jet
+    :height: 65
+    :width: 100%
 
 ##################################################
 


### PR DESCRIPTION
**Context:**
Uploading a package to PyPI with an RST description that contains a `raw` directive is prohibited.

**Description of the Change:**
- Removed the `raw` directive from the README.
- Updated the Python installation instructions to install Jet from PyPI (as opposed to GitHub).

**Benefits:**
- Jet wheels can be uploaded to PyPI.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.